### PR TITLE
MCU Receivers

### DIFF
--- a/src/FM.LiveSwitch.Connect/IReceiveOptionsExtensions.cs
+++ b/src/FM.LiveSwitch.Connect/IReceiveOptionsExtensions.cs
@@ -4,9 +4,17 @@ namespace FM.LiveSwitch.Connect
 {
     static class IReceiveOptionsExtensions
     {
-        public static SfuDownstreamConnection CreateConnection(this IReceiveOptions options, Channel channel, ConnectionInfo remoteConnectionInfo, AudioStream audioStream, VideoStream videoStream, DataStream dataStream, bool logState = true)
+        public static ManagedConnection CreateConnection(this IReceiveOptions options, Channel channel, ConnectionInfo remoteConnectionInfo, AudioStream audioStream, VideoStream videoStream, DataStream dataStream, bool logState = true)
         {
-            var connection = channel.CreateSfuDownstreamConnection(remoteConnectionInfo, audioStream, videoStream, dataStream);
+            ManagedConnection connection;
+            if (remoteConnectionInfo.Id == "mcu")
+            {
+                connection = channel.CreateMcuConnection(audioStream, videoStream, dataStream);
+            }
+            else
+            {
+                connection = channel.CreateSfuDownstreamConnection(remoteConnectionInfo, audioStream, videoStream, dataStream);
+            }
 
             connection.Tag = options.ConnectionTag;
 

--- a/src/FM.LiveSwitch.Connect/ReceiveOptions.cs
+++ b/src/FM.LiveSwitch.Connect/ReceiveOptions.cs
@@ -4,7 +4,7 @@ namespace FM.LiveSwitch.Connect
 {
     abstract class ReceiveOptions : Options, IReceiveOptions
     {
-        [Option("connection-id", Required = true, HelpText = "The remote connection ID.")]
+        [Option("connection-id", Required = true, HelpText = "The remote connection ID or 'mcu'.")]
         public string ConnectionId { get; set; }
     }
 }


### PR DESCRIPTION
A user can provide `mcu` as the `connection-id` when running a receiver-based command to get the MCU audio/video mix.