### PR TITLE
Transcoding RTP

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,8 @@ The `shell` verb starts an interactive shell that lets you monitor clients and c
   --application-id    Required. The application ID.
 
   --shared-secret     Required. The shared secret for the application ID.
+
+  --log-level         (Default: Error) The LiveSwitch log level.
 ```
 
 Once the `shell` is active:
@@ -152,15 +154,11 @@ The `capture` verb lets you capture local media from a named pipe and send it to
 
   --media-id                The local media ID.
 
-  --audio-bitrate           (Default: 32) The requested audio bitrate.
+  --audio-bitrate           The audio bitrate.
 
-  --video-bitrate           (Default: 1000) The requested video bitrate.
+  --video-bitrate           The video bitrate.
 
-  --gateway-url             Required. The gateway URL.
-
-  --application-id          Required. The application ID.
-
-  --shared-secret           Required. The shared secret for the application ID.
+  --video-frame-rate        The video frame-rate, if known, for signalling.
 
   --channel-id              Required. The channel ID.
 
@@ -189,6 +187,14 @@ The `capture` verb lets you capture local media from a named pipe and send it to
 
   --video-codec             (Default: Any) The video codec to negotiate with
                             LiveSwitch.
+
+  --gateway-url             Required. The gateway URL.
+
+  --application-id          Required. The application ID.
+
+  --shared-secret           Required. The shared secret for the application ID.
+
+  --log-level               (Default: Error) The LiveSwitch log level.
 ```
 
 ## FFCapture
@@ -203,21 +209,31 @@ The `ffcapture` verb lets you capture local media from FFmpeg and send it to a L
 
   --video-mode                    (Default: LSEncode) Where video is encoded.
 
+  --audio-encoding                The audio encoding of the input stream, if
+                                  different from audio-codec. Enables
+                                  transcoding if audio-mode is noencode or
+                                  ffencode.
+
+  --video-encoding                The video encoding of the input stream, if
+                                  different from video-codec. Enables
+                                  transcoding if video-mode is noencode or
+                                  ffencode.
+
   --ffencode-keyframe-interval    (Default: 30) The keyframe interval for video.
                                   Only used if video-mode is ffencode.
 
   --media-id                      The local media ID.
 
-  --audio-bitrate                 (Default: 32) The requested audio bitrate.
+  --audio-bitrate                 The audio bitrate.
 
-  --video-bitrate                 (Default: 1000) The requested video bitrate.
+  --video-bitrate                 The video bitrate.
 
-  --gateway-url                   Required. The gateway URL.
+  --video-width                   The video width, if known, for signalling.
 
-  --application-id                Required. The application ID.
+  --video-height                  The video height, if known, for signalling.
 
-  --shared-secret                 Required. The shared secret for the
-                                  application ID.
+  --video-frame-rate              The video frame-rate, if known, for
+                                  signalling.
 
   --channel-id                    Required. The channel ID.
 
@@ -246,6 +262,15 @@ The `ffcapture` verb lets you capture local media from FFmpeg and send it to a L
 
   --video-codec                   (Default: Any) The video codec to negotiate
                                   with LiveSwitch.
+
+  --gateway-url                   Required. The gateway URL.
+
+  --application-id                Required. The application ID.
+
+  --shared-secret                 Required. The shared secret for the
+                                  application ID.
+
+  --log-level                     (Default: Error) The LiveSwitch log level.
 ```
 
 ## Fake
@@ -269,10 +294,10 @@ The `fake` verb lets you generate fake media and send it to a LiveSwitch server.
 
   --video-format           (Default: Bgr) The video format.
 
-  --video-width            (Default: 640) The video width. Must be a multiiple
-                           of 2.
+  --video-width            (Default: 640) The video width. Must be a multiple of
+                           2.
 
-  --video-height           (Default: 480) The video height. Must be a multiiple
+  --video-height           (Default: 480) The video height. Must be a multiple
                            of 2.
 
   --video-frame-rate       (Default: 30) The video frame rate. Minimum value is
@@ -280,15 +305,9 @@ The `fake` verb lets you generate fake media and send it to a LiveSwitch server.
 
   --media-id               The local media ID.
 
-  --audio-bitrate          (Default: 32) The requested audio bitrate.
+  --audio-bitrate          The audio bitrate.
 
-  --video-bitrate          (Default: 1000) The requested video bitrate.
-
-  --gateway-url            Required. The gateway URL.
-
-  --application-id         Required. The application ID.
-
-  --shared-secret          Required. The shared secret for the application ID.
+  --video-bitrate          The video bitrate.
 
   --channel-id             Required. The channel ID.
 
@@ -317,6 +336,14 @@ The `fake` verb lets you generate fake media and send it to a LiveSwitch server.
 
   --video-codec            (Default: Any) The video codec to negotiate with
                            LiveSwitch.
+
+  --gateway-url            Required. The gateway URL.
+
+  --application-id         Required. The application ID.
+
+  --shared-secret          Required. The shared secret for the application ID.
+
+  --log-level              (Default: Error) The LiveSwitch log level.
 ```
 
 ## Play
@@ -331,15 +358,15 @@ The `play` verb lets you capture media from a local file (or pair of files) and 
 
   --media-id              The local media ID.
 
-  --audio-bitrate         (Default: 32) The requested audio bitrate.
+  --audio-bitrate         The audio bitrate.
 
-  --video-bitrate         (Default: 1000) The requested video bitrate.
+  --video-bitrate         The video bitrate.
 
-  --gateway-url           Required. The gateway URL.
+  --video-width           The video width, if known, for signalling.
 
-  --application-id        Required. The application ID.
+  --video-height          The video height, if known, for signalling.
 
-  --shared-secret         Required. The shared secret for the application ID.
+  --video-frame-rate      The video frame-rate, if known, for signalling.
 
   --channel-id            Required. The channel ID.
 
@@ -368,6 +395,14 @@ The `play` verb lets you capture media from a local file (or pair of files) and 
 
   --video-codec           (Default: Any) The video codec to negotiate with
                           LiveSwitch.
+
+  --gateway-url           Required. The gateway URL.
+
+  --application-id        Required. The application ID.
+
+  --shared-secret         Required. The shared secret for the application ID.
+
+  --log-level             (Default: Error) The LiveSwitch log level.
 ```
 
 ## Render
@@ -401,12 +436,6 @@ The `render` verb lets you render remote media from a LiveSwitch server to a nam
 
   --connection-id           Required. The remote connection ID or 'mcu'.
 
-  --gateway-url             Required. The gateway URL.
-
-  --application-id          Required. The application ID.
-
-  --shared-secret           Required. The shared secret for the application ID.
-
   --channel-id              Required. The channel ID.
 
   --data-channel-label      The data channel label.
@@ -434,6 +463,14 @@ The `render` verb lets you render remote media from a LiveSwitch server to a nam
 
   --video-codec             (Default: Any) The video codec to negotiate with
                             LiveSwitch.
+
+  --gateway-url             Required. The gateway URL.
+
+  --application-id          Required. The application ID.
+
+  --shared-secret           Required. The shared secret for the application ID.
+
+  --log-level               (Default: Error) The LiveSwitch log level.
 ```
 
 ## FFRender
@@ -446,12 +483,6 @@ The `ffrender` verb lets you render remote media from a LiveSwitch server to FFm
 
   --connection-id         Required. The remote connection ID or 'mcu'.
 
-  --gateway-url           Required. The gateway URL.
-
-  --application-id        Required. The application ID.
-
-  --shared-secret         Required. The shared secret for the application ID.
-
   --channel-id            Required. The channel ID.
 
   --data-channel-label    The data channel label.
@@ -479,6 +510,14 @@ The `ffrender` verb lets you render remote media from a LiveSwitch server to FFm
 
   --video-codec           (Default: Any) The video codec to negotiate with
                           LiveSwitch.
+
+  --gateway-url           Required. The gateway URL.
+
+  --application-id        Required. The application ID.
+
+  --shared-secret         Required. The shared secret for the application ID.
+
+  --log-level             (Default: Error) The LiveSwitch log level.
 ```
 
 ## Log
@@ -488,35 +527,29 @@ The `log` verb lets you log remote media frame details from a LiveSwitch server 
 ### Usage
 ```
   --audio-log             (Default: audio: {duration}ms
-                          {codec}/{clockRate}/{channelCount} frame received
+                          {encoding}/{clockRate}/{channelCount} frame received
                           ({footprint} bytes) for SSRC {synchronizationSource}
                           and timestamp {timestamp}) The audio log template.
                           Uses curly-brace syntax. Valid variables: footprint,
                           duration, clockRate, channelCount, mediaStreamId,
                           rtpStreamId, sequenceNumber, synchronizationSource,
-                          systemTimestamp, timestamp, codec, applicationId,
+                          systemTimestamp, timestamp, encoding, applicationId,
                           channelId, userId, userAlias, deviceId, deviceAlias,
                           clientId, clientTag, connectionId, connectionTag,
                           mediaId
 
-  --video-log             (Default: video: {width}x{height} {codec} frame
+  --video-log             (Default: video: {width}x{height} {encoding} frame
                           received ({footprint} bytes) for SSRC
                           {synchronizationSource} and timestamp {timestamp}) The
                           video log template. Uses curly-brace syntax. Valid
                           variables: footprint, width, height, mediaStreamId,
                           rtpStreamId, sequenceNumber, synchronizationSource,
-                          systemTimestamp, timestamp, codec, applicationId,
+                          systemTimestamp, timestamp, encoding, applicationId,
                           channelId, userId, userAlias, deviceId, deviceAlias,
                           clientId, clientTag, connectionId, connectionTag,
                           mediaId
 
   --connection-id         Required. The remote connection ID or 'mcu'.
-
-  --gateway-url           Required. The gateway URL.
-
-  --application-id        Required. The application ID.
-
-  --shared-secret         Required. The shared secret for the application ID.
 
   --channel-id            Required. The channel ID.
 
@@ -545,6 +578,14 @@ The `log` verb lets you log remote media frame details from a LiveSwitch server 
 
   --video-codec           (Default: Any) The video codec to negotiate with
                           LiveSwitch.
+
+  --gateway-url           Required. The gateway URL.
+
+  --application-id        Required. The application ID.
+
+  --shared-secret         Required. The shared secret for the application ID.
+
+  --log-level             (Default: Error) The LiveSwitch log level.
 ```
 
 ## Record
@@ -567,12 +608,6 @@ The `record` verb lets you record remote media from a LiveSwitch server to a loc
 
   --connection-id         Required. The remote connection ID or 'mcu'.
 
-  --gateway-url           Required. The gateway URL.
-
-  --application-id        Required. The application ID.
-
-  --shared-secret         Required. The shared secret for the application ID.
-
   --channel-id            Required. The channel ID.
 
   --data-channel-label    The data channel label.
@@ -600,6 +635,14 @@ The `record` verb lets you record remote media from a LiveSwitch server to a loc
 
   --video-codec           (Default: Any) The video codec to negotiate with
                           LiveSwitch.
+
+  --gateway-url           Required. The gateway URL.
+
+  --application-id        Required. The application ID.
+
+  --shared-secret         Required. The shared secret for the application ID.
+
+  --log-level             (Default: Error) The LiveSwitch log level.
 ```
 
 ## Intercept
@@ -620,12 +663,6 @@ The `intercept` verb lets you forward audio and/or video packets to a specific d
 
   --connection-id         Required. The remote connection ID or 'mcu'.
 
-  --gateway-url           Required. The gateway URL.
-
-  --application-id        Required. The application ID.
-
-  --shared-secret         Required. The shared secret for the application ID.
-
   --channel-id            Required. The channel ID.
 
   --data-channel-label    The data channel label.
@@ -653,6 +690,14 @@ The `intercept` verb lets you forward audio and/or video packets to a specific d
 
   --video-codec           (Default: Any) The video codec to negotiate with
                           LiveSwitch.
+
+  --gateway-url           Required. The gateway URL.
+
+  --application-id        Required. The application ID.
+
+  --shared-secret         Required. The shared secret for the application ID.
+
+  --log-level             (Default: Error) The LiveSwitch log level.
 ```
 
 ## Loopback Example
@@ -840,6 +885,18 @@ Sample file taken from here: https://file-examples.com/index.php/sample-video-fi
 Note that `-stream_loop -1` plays the file on a loop, `-r 30` indicates 30fps and `-vf scale=640:480` scales to 640x480. You may need to tweak these depending on your file and output requirements.
 ```
 lsconnect ffcapture ... --input-args="-stream_loop -1 -i test.mp4 -r 30 -vf scale=640:480"
+```
+
+### Stream from RTMP (e.g. OBS)
+
+Assuming a 1920x1080@30fps screen capture stream from OBS out to an RTMP server, you can direct that stream to LiveSwitch efficiently. The `video-mode` is `noencode` so `ffmpeg` acts as a passthrough, forwarding the RTP packets through to `lsconnect` without decoding or modifying them. Because of this, we have to declare the `video-encoding`, which from OBS is typically `h264`. By declaring both a `video-encoding` and `video-codec`, we are also forcing transcoding, which allows us to respond to keyframe requests as remote clients access the feed more efficiently than can be done by relying on the OBS feed alone. In this case, we are selecting `vp8` as the `video-codec` to negotiate with the LiveSwitch server, which is efficient and broadly supported by WebRTC clients.
+
+If we know the `video-width`, `video-height`, and/or `video-frame-rate` ahead of time, it is helpful to declare them so this information can be signalled to the LiveSwitch server to assist with bitrate estimation and bandwidth adaptation. The `video-bitrate` can also be set if desired.
+```
+lsconnect ffcapture ... --input-args=-i rtmp://{server}/live/obs \
+  --video-mode noencode --video-encoding h264 --video-codec vp8 \
+  --video-width 1920 --video-height 1080 --video-frame-rate 30 \
+  --video-bitrate 3000
 ```
 
 ## Contact

--- a/src/FM.LiveSwitch.Connect/AudioCodecExtensions.cs
+++ b/src/FM.LiveSwitch.Connect/AudioCodecExtensions.cs
@@ -4,91 +4,20 @@ namespace FM.LiveSwitch.Connect
 {
     static class AudioCodecExtensions
     {
-        public static AudioEncoder CreateEncoder(this AudioCodec codec)
+        public static AudioEncoding ToEncoding(this AudioCodec codec)
         {
             switch (codec)
             {
                 case AudioCodec.Opus:
-                    return new Opus.Encoder();
+                    return AudioEncoding.Opus;
                 case AudioCodec.G722:
-                    return new G722.Encoder();
+                    return AudioEncoding.G722;
                 case AudioCodec.PCMU:
-                    return new Pcmu.Encoder();
+                    return AudioEncoding.PCMU;
                 case AudioCodec.PCMA:
-                    return new Pcma.Encoder();
-                default:
-                    throw new Exception("Unknown audio codec.");
-            }
-        }
-
-        public static AudioDecoder CreateDecoder(this AudioCodec codec)
-        {
-            switch (codec)
-            {
-                case AudioCodec.Opus:
-                    return new Opus.Decoder();
-                case AudioCodec.G722:
-                    return new G722.Decoder();
-                case AudioCodec.PCMU:
-                    return new Pcmu.Decoder();
-                case AudioCodec.PCMA:
-                    return new Pcma.Decoder();
-                default:
-                    throw new Exception("Unknown audio codec.");
-            }
-        }
-
-        public static AudioPacketizer CreatePacketizer(this AudioCodec codec)
-        {
-            switch (codec)
-            {
-                case AudioCodec.Opus:
-                    return new Opus.Packetizer();
-                case AudioCodec.G722:
-                    return new G722.Packetizer();
-                case AudioCodec.PCMU:
-                    return new Pcmu.Packetizer();
-                case AudioCodec.PCMA:
-                    return new Pcma.Packetizer();
-                default:
-                    throw new Exception("Unknown audio codec.");
-            }
-        }
-
-        public static AudioDepacketizer CreateDepacketizer(this AudioCodec codec)
-        {
-            switch (codec)
-            {
-                case AudioCodec.Opus:
-                    return new Opus.Depacketizer();
-                case AudioCodec.G722:
-                    return new G722.Depacketizer();
-                case AudioCodec.PCMU:
-                    return new Pcmu.Depacketizer();
-                case AudioCodec.PCMA:
-                    return new Pcma.Depacketizer();
-                default:
-                    throw new Exception("Unknown audio codec.");
-            }
-        }
-
-        public static NullAudioSink CreateNullSink(this AudioCodec codec, bool isPacketized)
-        {
-            return new NullAudioSink(CreateFormat(codec, isPacketized));
-        }
-
-        public static AudioFormat CreateFormat(this AudioCodec codec, bool isPacketized = false)
-        {
-            switch (codec)
-            {
-                case AudioCodec.Opus:
-                    return new Opus.Format() { IsPacketized = isPacketized };
-                case AudioCodec.G722:
-                    return new G722.Format() { IsPacketized = isPacketized, ClockRate = isPacketized ? 8000 : 16000 };
-                case AudioCodec.PCMU:
-                    return new Pcmu.Format() { IsPacketized = isPacketized };
-                case AudioCodec.PCMA:
-                    return new Pcma.Format() { IsPacketized = isPacketized };
+                    return AudioEncoding.PCMA;
+                case AudioCodec.Any:
+                    throw new Exception("Cannot convert 'any' codec to encoding.");
                 default:
                     throw new Exception("Unknown audio codec.");
             }

--- a/src/FM.LiveSwitch.Connect/AudioEncoding.cs
+++ b/src/FM.LiveSwitch.Connect/AudioEncoding.cs
@@ -1,0 +1,10 @@
+﻿namespace FM.LiveSwitch.Connect
+{
+    enum AudioEncoding
+    {
+        Opus,
+        G722,
+        PCMU,
+        PCMA
+    }
+}

--- a/src/FM.LiveSwitch.Connect/AudioEncodingExtensions.cs
+++ b/src/FM.LiveSwitch.Connect/AudioEncodingExtensions.cs
@@ -1,0 +1,114 @@
+﻿using System;
+
+namespace FM.LiveSwitch.Connect
+{
+    static class AudioEncodingExtensions
+    {
+        public static AudioCodec ToCodec(this AudioEncoding encoding)
+        {
+            switch (encoding)
+            {
+                case AudioEncoding.Opus:
+                    return AudioCodec.Opus;
+                case AudioEncoding.G722:
+                    return AudioCodec.G722;
+                case AudioEncoding.PCMU:
+                    return AudioCodec.PCMU;
+                case AudioEncoding.PCMA:
+                    return AudioCodec.PCMA;
+                default:
+                    throw new Exception("Unknown audio encoding.");
+            }
+        }
+
+        public static AudioEncoder CreateEncoder(this AudioEncoding encoding)
+        {
+            switch (encoding)
+            {
+                case AudioEncoding.Opus:
+                    return new Opus.Encoder();
+                case AudioEncoding.G722:
+                    return new G722.Encoder();
+                case AudioEncoding.PCMU:
+                    return new Pcmu.Encoder();
+                case AudioEncoding.PCMA:
+                    return new Pcma.Encoder();
+                default:
+                    throw new Exception("Unknown audio encoding.");
+            }
+        }
+
+        public static AudioDecoder CreateDecoder(this AudioEncoding encoding)
+        {
+            switch (encoding)
+            {
+                case AudioEncoding.Opus:
+                    return new Opus.Decoder();
+                case AudioEncoding.G722:
+                    return new G722.Decoder();
+                case AudioEncoding.PCMU:
+                    return new Pcmu.Decoder();
+                case AudioEncoding.PCMA:
+                    return new Pcma.Decoder();
+                default:
+                    throw new Exception("Unknown audio encoding.");
+            }
+        }
+
+        public static AudioPacketizer CreatePacketizer(this AudioEncoding encoding)
+        {
+            switch (encoding)
+            {
+                case AudioEncoding.Opus:
+                    return new Opus.Packetizer();
+                case AudioEncoding.G722:
+                    return new G722.Packetizer();
+                case AudioEncoding.PCMU:
+                    return new Pcmu.Packetizer();
+                case AudioEncoding.PCMA:
+                    return new Pcma.Packetizer();
+                default:
+                    throw new Exception("Unknown audio encoding.");
+            }
+        }
+
+        public static AudioDepacketizer CreateDepacketizer(this AudioEncoding encoding)
+        {
+            switch (encoding)
+            {
+                case AudioEncoding.Opus:
+                    return new Opus.Depacketizer();
+                case AudioEncoding.G722:
+                    return new G722.Depacketizer();
+                case AudioEncoding.PCMU:
+                    return new Pcmu.Depacketizer();
+                case AudioEncoding.PCMA:
+                    return new Pcma.Depacketizer();
+                default:
+                    throw new Exception("Unknown audio encoding.");
+            }
+        }
+
+        public static NullAudioSink CreateNullSink(this AudioEncoding encoding, bool isPacketized)
+        {
+            return new NullAudioSink(CreateFormat(encoding, isPacketized));
+        }
+
+        public static AudioFormat CreateFormat(this AudioEncoding encoding, bool isPacketized = false)
+        {
+            switch (encoding)
+            {
+                case AudioEncoding.Opus:
+                    return new Opus.Format() { IsPacketized = isPacketized };
+                case AudioEncoding.G722:
+                    return new G722.Format() { IsPacketized = isPacketized, ClockRate = isPacketized ? 8000 : 16000 };
+                case AudioEncoding.PCMU:
+                    return new Pcmu.Format() { IsPacketized = isPacketized };
+                case AudioEncoding.PCMA:
+                    return new Pcma.Format() { IsPacketized = isPacketized };
+                default:
+                    throw new Exception("Unknown audio encoding.");
+            }
+        }
+    }
+}

--- a/src/FM.LiveSwitch.Connect/AudioFormatExtensions.cs
+++ b/src/FM.LiveSwitch.Connect/AudioFormatExtensions.cs
@@ -4,23 +4,23 @@ namespace FM.LiveSwitch.Connect
 {
     static class AudioFormatExtensions
     {
-        public static AudioCodec CreateCodec(this AudioFormat format)
+        public static AudioEncoding ToEncoding(this AudioFormat format)
         {
             if (format.Name == AudioFormat.OpusName)
             {
-                return AudioCodec.Opus;
+                return AudioEncoding.Opus;
             }
             if (format.Name == AudioFormat.G722Name)
             {
-                return AudioCodec.G722;
+                return AudioEncoding.G722;
             }
             if (format.Name == AudioFormat.PcmuName)
             {
-                return AudioCodec.PCMU;
+                return AudioEncoding.PCMU;
             }
             if (format.Name == AudioFormat.PcmaName)
             {
-                return AudioCodec.PCMA;
+                return AudioEncoding.PCMA;
             }
             throw new Exception("Unknown audio format.");
         }

--- a/src/FM.LiveSwitch.Connect/CaptureOptions.cs
+++ b/src/FM.LiveSwitch.Connect/CaptureOptions.cs
@@ -27,9 +27,9 @@ namespace FM.LiveSwitch.Connect
         public ImageFormat VideoFormat { get; set; }
 
         [Option("video-width", Required = false, HelpText = "The video width.")]
-        public int VideoWidth { get; set; }
+        public new int? VideoWidth { get; set; }
 
         [Option("video-height", Required = false, HelpText = "The video height.")]
-        public int VideoHeight { get; set; }
+        public new int? VideoHeight { get; set; }
     }
 }

--- a/src/FM.LiveSwitch.Connect/Capturer.cs
+++ b/src/FM.LiveSwitch.Connect/Capturer.cs
@@ -56,12 +56,12 @@ namespace FM.LiveSwitch.Connect
             }
             if (Options.VideoPipe != null)
             {
-                if (Options.VideoWidth == 0)
+                if (!Options.VideoWidth.HasValue || Options.VideoWidth == 0)
                 {
                     Console.Error.WriteLine("--video-width must be a specified if --video-pipe is specified.");
                     return Task.FromResult(1);
                 }
-                if (Options.VideoHeight == 0)
+                if (!Options.VideoHeight.HasValue || Options.VideoHeight == 0)
                 {
                     Console.Error.WriteLine("--video-height must be a specified if --video-pipe is specified.");
                     return Task.FromResult(1);
@@ -92,7 +92,7 @@ namespace FM.LiveSwitch.Connect
 
         protected override NamedPipeVideoSource CreateVideoSource()
         {
-            var source = new NamedPipeVideoSource(Options.VideoPipe, Options.VideoWidth, Options.VideoHeight, Options.VideoFormat.CreateFormat(), Options.Server);
+            var source = new NamedPipeVideoSource(Options.VideoPipe, Options.VideoWidth.Value, Options.VideoHeight.Value, Options.VideoFormat.CreateFormat(), Options.Server);
             source.OnPipeConnected += () =>
             {
                 Console.Error.WriteLine("Video pipe connected.");

--- a/src/FM.LiveSwitch.Connect/FFCaptureOptions.cs
+++ b/src/FM.LiveSwitch.Connect/FFCaptureOptions.cs
@@ -14,6 +14,12 @@ namespace FM.LiveSwitch.Connect
         [Option("video-mode", Required = false, Default = FFCaptureMode.LSEncode, HelpText = "Where video is encoded.")]
         public FFCaptureMode VideoMode { get; set; }
 
+        [Option("audio-encoding", Required = false, HelpText = "The audio encoding of the input stream, if different from audio-codec. Enables transcoding if audio-mode is noencode or ffencode.")]
+        public AudioEncoding? AudioEncoding { get; set; }
+
+        [Option("video-encoding", Required = false, HelpText = "The video encoding of the input stream, if different from video-codec. Enables transcoding if video-mode is noencode or ffencode.")]
+        public VideoEncoding? VideoEncoding { get; set; }
+
         [Option("ffencode-keyframe-interval", Required = false, Default = 30, HelpText = "The keyframe interval for video. Only used if video-mode is ffencode.")]
         public int FFEncodeKeyFrameInterval { get; set; }
     }

--- a/src/FM.LiveSwitch.Connect/FFRenderer.cs
+++ b/src/FM.LiveSwitch.Connect/FFRenderer.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Diagnostics;
-using System.Linq;
 using System.Threading.Tasks;
 
 namespace FM.LiveSwitch.Connect
@@ -71,9 +70,9 @@ namespace FM.LiveSwitch.Connect
             };
 
             var tracks = new List<AudioTrack>();
-            foreach (var codec in ((AudioCodec[])Enum.GetValues(typeof(AudioCodec))).Where(x => x != AudioCodec.Any))
+            foreach (var encoding in (AudioEncoding[])Enum.GetValues(typeof(AudioEncoding)))
             {
-                tracks.Add(CreateAudioTrack(codec));
+                tracks.Add(CreateAudioTrack(encoding));
             }
             return new AudioTrack(tracks.ToArray()).Next(sink);
         }
@@ -87,29 +86,29 @@ namespace FM.LiveSwitch.Connect
             };
 
             var tracks = new List<VideoTrack>();
-            foreach (var codec in ((VideoCodec[])Enum.GetValues(typeof(VideoCodec))).Where(x => x != VideoCodec.Any))
+            foreach (var encoding in (VideoEncoding[])Enum.GetValues(typeof(VideoEncoding)))
             {
-                if (Options.DisableOpenH264 && codec == VideoCodec.H264)
+                if (Options.DisableOpenH264 && encoding == VideoEncoding.H264)
                 {
                     continue;
                 }
-                tracks.Add(CreateVideoTrack(codec));
+                tracks.Add(CreateVideoTrack(encoding));
             }
             return new VideoTrack(tracks.ToArray()).Next(sink);
         }
 
-        private AudioTrack CreateAudioTrack(AudioCodec codec)
+        private AudioTrack CreateAudioTrack(AudioEncoding encoding)
         {
-            var depacketizer = codec.CreateDepacketizer();
-            var decoder = codec.CreateDecoder();
+            var depacketizer = encoding.CreateDepacketizer();
+            var decoder = encoding.CreateDecoder();
             var converter = new SoundConverter(Opus.Format.DefaultConfig);
             return new AudioTrack(depacketizer).Next(decoder).Next(converter);
         }
 
-        private VideoTrack CreateVideoTrack(VideoCodec codec)
+        private VideoTrack CreateVideoTrack(VideoEncoding encoding)
         {
-            var depacketizer = codec.CreateDepacketizer();
-            var decoder = codec.CreateDecoder();
+            var depacketizer = encoding.CreateDepacketizer();
+            var decoder = encoding.CreateDecoder();
             var converter = new Yuv.ImageConverter(VideoFormat.I420); //TODO: use matroska and remove this?
             return new VideoTrack(depacketizer).Next(decoder).Next(converter);
         }

--- a/src/FM.LiveSwitch.Connect/FM.LiveSwitch.Connect.csproj
+++ b/src/FM.LiveSwitch.Connect/FM.LiveSwitch.Connect.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
@@ -13,11 +13,11 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.Extensions.Logging" Version="3.1.3" />
-    <PackageReference Include="FM.LiveSwitch.Opus" Version="1.8.1.24993" />
-    <PackageReference Include="FM.LiveSwitch.Yuv" Version="1.8.1.24993" />
-    <PackageReference Include="FM.LiveSwitch.Vpx" Version="1.8.1.24993" />
-    <PackageReference Include="FM.LiveSwitch.OpenH264" Version="1.8.1.24993" />
-    <PackageReference Include="FM.LiveSwitch" Version="1.8.1.24993" />
+    <PackageReference Include="FM.LiveSwitch.Opus" Version="1.9.3.31084" />
+    <PackageReference Include="FM.LiveSwitch.Yuv" Version="1.9.3.31084" />
+    <PackageReference Include="FM.LiveSwitch.Vpx" Version="1.9.3.31084" />
+    <PackageReference Include="FM.LiveSwitch.OpenH264" Version="1.9.3.31084" />
+    <PackageReference Include="FM.LiveSwitch" Version="1.9.3.31084" />
   </ItemGroup>
 
 </Project>

--- a/src/FM.LiveSwitch.Connect/FakeOptions.cs
+++ b/src/FM.LiveSwitch.Connect/FakeOptions.cs
@@ -20,13 +20,13 @@ namespace FM.LiveSwitch.Connect
         [Option("video-format", Required = false, Default = ImageFormat.Bgr, HelpText = "The video format.")]
         public ImageFormat VideoFormat { get; set; }
 
-        [Option("video-width", Required = false, Default = 640, HelpText = "The video width. Must be a multiiple of 2.")]
-        public int VideoWidth { get; set; }
+        [Option("video-width", Required = false, Default = 640, HelpText = "The video width. Must be a multiple of 2.")]
+        public new int? VideoWidth { get; set; }
 
-        [Option("video-height", Required = false, Default = 480, HelpText = "The video height. Must be a multiiple of 2.")]
-        public int VideoHeight { get; set; }
+        [Option("video-height", Required = false, Default = 480, HelpText = "The video height. Must be a multiple of 2.")]
+        public new int? VideoHeight { get; set; }
 
         [Option("video-frame-rate", Required = false, Default = 30, HelpText = "The video frame rate. Minimum value is 1. Maximum value is 120.")]
-        public double VideoFrameRate { get; set; }
+        public new double? VideoFrameRate { get; set; }
     }
 }

--- a/src/FM.LiveSwitch.Connect/Faker.cs
+++ b/src/FM.LiveSwitch.Connect/Faker.cs
@@ -61,12 +61,12 @@ namespace FM.LiveSwitch.Connect
             }
             if (!Options.NoVideo)
             {
-                if (Options.VideoWidth == 0)
+                if (!Options.VideoWidth.HasValue || Options.VideoWidth == 0)
                 {
                     Console.Error.WriteLine("--video-width must be a specified if --video-pipe is specified.");
                     return Task.FromResult(1);
                 }
-                if (Options.VideoHeight == 0)
+                if (!Options.VideoHeight.HasValue || Options.VideoHeight == 0)
                 {
                     Console.Error.WriteLine("--video-height must be a specified if --video-pipe is specified.");
                     return Task.FromResult(1);
@@ -81,7 +81,7 @@ namespace FM.LiveSwitch.Connect
                     Console.Error.WriteLine("--video-height must be a multiple of 2.");
                     return Task.FromResult(1);
                 }
-                if (Options.VideoFrameRate < 1)
+                if (!Options.VideoFrameRate.HasValue || Options.VideoFrameRate < 1)
                 {
                     Console.Error.WriteLine("--video-frame-rate minimum value is 1.");
                     return Task.FromResult(1);
@@ -102,7 +102,7 @@ namespace FM.LiveSwitch.Connect
 
         protected override FakeVideoSource CreateVideoSource()
         {
-            return new FakeVideoSource(new VideoConfig(Options.VideoWidth, Options.VideoHeight, Options.VideoFrameRate), Options.VideoFormat.CreateFormat());
+            return new FakeVideoSource(new VideoConfig(Options.VideoWidth.Value, Options.VideoHeight.Value, Options.VideoFrameRate.Value), Options.VideoFormat.CreateFormat());
         }
     }
 }

--- a/src/FM.LiveSwitch.Connect/IConnectionOptionsExtensions.cs
+++ b/src/FM.LiveSwitch.Connect/IConnectionOptionsExtensions.cs
@@ -5,22 +5,22 @@ namespace FM.LiveSwitch.Connect
 {
     static class IConnectionOptionsExtensions
     {
-        public static AudioCodec[] GetAudioCodecs(this IConnectionOptions options)
+        public static AudioEncoding[] GetAudioEncodings(this IConnectionOptions options)
         {
             if (options.AudioCodec == AudioCodec.Any)
             {
-                return ((AudioCodec[])Enum.GetValues(typeof(AudioCodec))).Where(x => x != AudioCodec.Any).ToArray();
+                return ((AudioEncoding[])Enum.GetValues(typeof(AudioEncoding))).ToArray();
             }
-            return new[] { options.AudioCodec };
+            return new[] { options.AudioCodec.ToEncoding() };
         }
 
-        public static VideoCodec[] GetVideoCodecs(this IConnectionOptions options)
+        public static VideoEncoding[] GetVideoEncodings(this IConnectionOptions options)
         {
             if (options.VideoCodec == VideoCodec.Any)
             {
-                return ((VideoCodec[])Enum.GetValues(typeof(VideoCodec))).Where(x => x != VideoCodec.Any).ToArray();
+                return ((VideoEncoding[])Enum.GetValues(typeof(VideoEncoding))).ToArray();
             }
-            return new[] { options.VideoCodec };
+            return new[] { options.VideoCodec.ToEncoding() };
         }
     }
 }

--- a/src/FM.LiveSwitch.Connect/ISendOptions.cs
+++ b/src/FM.LiveSwitch.Connect/ISendOptions.cs
@@ -4,8 +4,18 @@
     {
         string MediaId { get; }
 
-        int AudioBitrate { get; }
+        bool AudioTranscode { get; }
 
-        int VideoBitrate { get; }
+        bool VideoTranscode { get; }
+
+        int? AudioBitrate { get; }
+
+        int? VideoBitrate { get; }
+
+        int? VideoWidth { get; set; }
+
+        int? VideoHeight { get; set; }
+
+        double? VideoFrameRate { get; set; }
     }
 }

--- a/src/FM.LiveSwitch.Connect/Interceptor.cs
+++ b/src/FM.LiveSwitch.Connect/Interceptor.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Linq;
 using System.Net;
 using System.Net.Sockets;
 using System.Threading.Tasks;
@@ -82,9 +81,9 @@ namespace FM.LiveSwitch.Connect
         private AudioTrack CreateAudioTrack(ConnectionInfo remoteConnectionInfo)
         {
             var tracks = new List<AudioTrack>();
-            foreach (var codec in ((AudioCodec[])Enum.GetValues(typeof(AudioCodec))).Where(x => x != AudioCodec.Any))
+            foreach (var encoding in (AudioEncoding[])Enum.GetValues(typeof(AudioEncoding)))
             {
-                tracks.Add(CreateAudioTrack(codec, remoteConnectionInfo));
+                tracks.Add(CreateAudioTrack(encoding, remoteConnectionInfo));
             }
             return new AudioTrack(tracks.ToArray());
         }
@@ -92,22 +91,22 @@ namespace FM.LiveSwitch.Connect
         private VideoTrack CreateVideoTrack(ConnectionInfo remoteConnectionInfo)
         {
             var tracks = new List<VideoTrack>();
-            foreach (var codec in ((VideoCodec[])Enum.GetValues(typeof(VideoCodec))).Where(x => x != VideoCodec.Any))
+            foreach (var encoding in (VideoEncoding[])Enum.GetValues(typeof(VideoEncoding)))
             {
-                if (Options.DisableOpenH264 && codec == VideoCodec.H264)
+                if (Options.DisableOpenH264 && encoding == VideoEncoding.H264)
                 {
                     continue;
                 }
-                tracks.Add(CreateVideoTrack(codec, remoteConnectionInfo));
+                tracks.Add(CreateVideoTrack(encoding, remoteConnectionInfo));
             }
             return new VideoTrack(tracks.ToArray());
         }
 
-        private AudioTrack CreateAudioTrack(AudioCodec codec, ConnectionInfo remoteConnectionInfo)
+        private AudioTrack CreateAudioTrack(AudioEncoding encoding, ConnectionInfo remoteConnectionInfo)
         {
             var socket = GetSocket(TransportAddress.IsIPv6(Options.AudioIPAddress));
             var remoteEndPoint = new IPEndPoint(IPAddress.Parse(Options.AudioIPAddress), Options.AudioPort);
-            var sink = codec.CreateNullSink(true);
+            var sink = encoding.CreateNullSink(true);
             sink.OnProcessFrame += (frame) =>
             {
                 var buffer = frame.LastBuffer;
@@ -123,11 +122,11 @@ namespace FM.LiveSwitch.Connect
             return new AudioTrack(sink);
         }
 
-        private VideoTrack CreateVideoTrack(VideoCodec codec, ConnectionInfo remoteConnectionInfo)
+        private VideoTrack CreateVideoTrack(VideoEncoding encoding, ConnectionInfo remoteConnectionInfo)
         {
             var socket = GetSocket(TransportAddress.IsIPv6(Options.VideoIPAddress));
             var remoteEndPoint = new IPEndPoint(IPAddress.Parse(Options.VideoIPAddress), Options.VideoPort);
-            var sink = codec.CreateNullSink(true);
+            var sink = encoding.CreateNullSink(true);
             sink.OnProcessFrame += (frame) =>
             {
                 var buffer = frame.LastBuffer;

--- a/src/FM.LiveSwitch.Connect/LogOptions.cs
+++ b/src/FM.LiveSwitch.Connect/LogOptions.cs
@@ -5,10 +5,10 @@ namespace FM.LiveSwitch.Connect
     [Verb("log", HelpText = "Logs remote media to stdout.")]
     class LogOptions : ReceiveOptions
     {
-        [Option("audio-log", Required = false, Default = "audio: {duration}ms {codec}/{clockRate}/{channelCount} frame received ({footprint} bytes) for SSRC {synchronizationSource} and timestamp {timestamp}", HelpText = "The audio log template. Uses curly-brace syntax. Valid variables: footprint, duration, clockRate, channelCount, mediaStreamId, rtpStreamId, sequenceNumber, synchronizationSource, systemTimestamp, timestamp, codec, applicationId, channelId, userId, userAlias, deviceId, deviceAlias, clientId, clientTag, connectionId, connectionTag, mediaId")]
+        [Option("audio-log", Required = false, Default = "audio: {duration}ms {encoding}/{clockRate}/{channelCount} frame received ({footprint} bytes) for SSRC {synchronizationSource} and timestamp {timestamp}", HelpText = "The audio log template. Uses curly-brace syntax. Valid variables: footprint, duration, clockRate, channelCount, mediaStreamId, rtpStreamId, sequenceNumber, synchronizationSource, systemTimestamp, timestamp, encoding, applicationId, channelId, userId, userAlias, deviceId, deviceAlias, clientId, clientTag, connectionId, connectionTag, mediaId")]
         public string AudioLog { get; set; }
 
-        [Option("video-log", Required = false, Default = "video: {width}x{height} {codec} frame received ({footprint} bytes) for SSRC {synchronizationSource} and timestamp {timestamp}", HelpText = "The video log template. Uses curly-brace syntax. Valid variables: footprint, width, height, mediaStreamId, rtpStreamId, sequenceNumber, synchronizationSource, systemTimestamp, timestamp, codec, applicationId, channelId, userId, userAlias, deviceId, deviceAlias, clientId, clientTag, connectionId, connectionTag, mediaId")]
+        [Option("video-log", Required = false, Default = "video: {width}x{height} {encoding} frame received ({footprint} bytes) for SSRC {synchronizationSource} and timestamp {timestamp}", HelpText = "The video log template. Uses curly-brace syntax. Valid variables: footprint, width, height, mediaStreamId, rtpStreamId, sequenceNumber, synchronizationSource, systemTimestamp, timestamp, encoding, applicationId, channelId, userId, userAlias, deviceId, deviceAlias, clientId, clientTag, connectionId, connectionTag, mediaId")]
         public string VideoLog { get; set; }
     }
 }

--- a/src/FM.LiveSwitch.Connect/NamedPipeAudioSource.cs
+++ b/src/FM.LiveSwitch.Connect/NamedPipeAudioSource.cs
@@ -121,6 +121,8 @@ namespace FM.LiveSwitch.Connect
 
         protected virtual void RaiseFramePayload(DataBuffer dataBuffer)
         {
+            dataBuffer.LittleEndian = OutputFormat.LittleEndian;
+
             RaiseFrame(new AudioFrame(FrameDuration, new AudioBuffer(dataBuffer, OutputFormat)));
         }
 

--- a/src/FM.LiveSwitch.Connect/Options.cs
+++ b/src/FM.LiveSwitch.Connect/Options.cs
@@ -3,7 +3,7 @@ using System.Collections.Generic;
 
 namespace FM.LiveSwitch.Connect
 {
-    abstract class Options : IConnectionOptions, IChannelOptions, IClientOptions
+    abstract class Options
     {
         public bool DisableOpenH264 { get; set; }
 
@@ -16,43 +16,7 @@ namespace FM.LiveSwitch.Connect
         [Option("shared-secret", Required = true, HelpText = "The shared secret for the application ID.")]
         public string SharedSecret { get; set; }
 
-        [Option("channel-id", Required = true, HelpText = "The channel ID.")]
-        public string ChannelId { get; set; }
-
-        [Option("data-channel-label", Required = false, HelpText = "The data channel label.")]
-        public string DataChannelLabel { get; set; }
-
-        [Option("user-id", Required = false, HelpText = "The local user ID.")]
-        public string UserId { get; set; }
-
-        [Option("user-alias", Required = false, HelpText = "The local user alias.")]
-        public string UserAlias { get; set; }
-
-        [Option("device-id", Required = false, HelpText = "The local device ID.")]
-        public string DeviceId { get; set; }
-
-        [Option("device-alias", Required = false, HelpText = "The local device alias.")]
-        public string DeviceAlias { get; set; }
-
-        [Option("client-tag", Required = false, HelpText = "The local client tag.")]
-        public string ClientTag { get; set; }
-
-        [Option("client-roles", Required = false, HelpText = "The local client roles.")]
-        public IEnumerable<string> ClientRoles { get; set; }
-
-        [Option("connection-tag", Required = false, HelpText = "The local connection tag.")]
-        public string ConnectionTag { get; set; }
-
-        [Option("no-audio", Required = false, HelpText = "Do not process audio.")]
-        public bool NoAudio { get; set; }
-
-        [Option("no-video", Required = false, HelpText = "Do not process video.")]
-        public bool NoVideo { get; set; }
-
-        [Option("audio-codec", Required = false, Default = AudioCodec.Any, HelpText = "The audio codec to negotiate with LiveSwitch.")]
-        public AudioCodec AudioCodec { get; set; }
-
-        [Option("video-codec", Required = false, Default = VideoCodec.Any, HelpText = "The video codec to negotiate with LiveSwitch.")]
-        public VideoCodec VideoCodec { get; set; }
+        [Option("log-level", Required = false, Default = LogLevel.Error, HelpText = "The LiveSwitch log level.")]
+        public LogLevel LogLevel { get; set; }
     }
 }

--- a/src/FM.LiveSwitch.Connect/Program.cs
+++ b/src/FM.LiveSwitch.Connect/Program.cs
@@ -11,28 +11,6 @@ namespace FM.LiveSwitch.Connect
     {
         static void Main(string[] args)
         {
-            Log.AddProvider(new ErrorLogProvider(LogLevel.Error));
-
-            Console.Error.WriteLine("Checking for OpenH264...");
-            OpenH264.Utility.DownloadOpenH264(Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location)).GetAwaiter().GetResult();
-            var disableOpenH264 = true;
-            try
-            {
-                disableOpenH264 = !OpenH264.Utility.Initialize();
-                if (disableOpenH264)
-                {
-                    Console.Error.WriteLine("OpenH264 failed to initialize.");
-                }
-                else
-                {
-                    Console.Error.WriteLine("OpenH264 initialized.");
-                }
-            }
-            catch (Exception ex)
-            {
-                Console.Error.WriteLine("OpenH264 failed to initialize.", ex);
-            }
-
             using var parser = new Parser((settings) =>
             {
                 settings.CaseInsensitiveEnumValues = true;
@@ -55,81 +33,81 @@ namespace FM.LiveSwitch.Connect
             result.MapResult(
                 (ShellOptions options) =>
                 {
-                    options.DisableOpenH264 = disableOpenH264;
                     return Task.Run(async () =>
                     {
+                        Initialize(options);
                         return await new ShellRunner(options).Run();
                     }).GetAwaiter().GetResult();
                 },
                 (CaptureOptions options) =>
                 {
-                    options.DisableOpenH264 = disableOpenH264;
                     return Task.Run(async () =>
                     {
+                        Initialize(options);
                         return await new Capturer(options).Capture();
                     }).GetAwaiter().GetResult();
                 },
                 (FFCaptureOptions options) =>
                 {
-                    options.DisableOpenH264 = disableOpenH264;
                     return Task.Run(async () =>
                     {
+                        Initialize(options);
                         return await new FFCapturer(options).Capture();
                     }).GetAwaiter().GetResult();
                 },
                 (FakeOptions options) =>
                 {
-                    options.DisableOpenH264 = disableOpenH264;
                     return Task.Run(async () =>
                     {
+                        Initialize(options);
                         return await new Faker(options).Fake();
                     }).GetAwaiter().GetResult();
                 },
                 (PlayOptions options) =>
                 {
-                    options.DisableOpenH264 = disableOpenH264;
                     return Task.Run(async () =>
                     {
+                        Initialize(options);
                         return await new Player(options).Play();
                     }).GetAwaiter().GetResult();
                 },
                 (RenderOptions options) =>
                 {
-                    options.DisableOpenH264 = disableOpenH264;
                     return Task.Run(async () =>
                     {
+                        Initialize(options);
                         return await new Renderer(options).Render();
                     }).GetAwaiter().GetResult();
                 },
                 (FFRenderOptions options) =>
                 {
-                    options.DisableOpenH264 = disableOpenH264;
                     return Task.Run(async () =>
                     {
+                        Initialize(options);
                         return await new FFRenderer(options).Render();
                     }).GetAwaiter().GetResult();
                 },
                 (LogOptions options) =>
                 {
-                    options.DisableOpenH264 = disableOpenH264;
                     return Task.Run(async () =>
                     {
+                        Initialize(options);
                         return await new Logger(options).Log();
                     }).GetAwaiter().GetResult();
                 },
                 (RecordOptions options) =>
                 {
-                    options.DisableOpenH264 = disableOpenH264;
                     return Task.Run(async () =>
                     {
+                        Initialize(options);
                         return await new Recorder(options).Record();
                     }).GetAwaiter().GetResult();
                 },
                 (InterceptOptions options) =>
                 {
-                    options.DisableOpenH264 = disableOpenH264;
                     return Task.Run(async () =>
                     {
+                        Initialize(options);
                         return await new Interceptor(options).Intercept();
                     }).GetAwaiter().GetResult();
                 },
@@ -141,6 +119,31 @@ namespace FM.LiveSwitch.Connect
                     Console.Error.Write(helpText);
                     return 1;
                 });
+        }
+
+        private static void Initialize(Options options)
+        {
+            Log.AddProvider(new ErrorLogProvider(options.LogLevel));
+
+            Console.Error.WriteLine("Checking for OpenH264...");
+            OpenH264.Utility.DownloadOpenH264(Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location)).GetAwaiter().GetResult();
+            options.DisableOpenH264 = true;
+            try
+            {
+                options.DisableOpenH264 = !OpenH264.Utility.Initialize();
+                if (options.DisableOpenH264)
+                {
+                    Console.Error.WriteLine("OpenH264 failed to initialize.");
+                }
+                else
+                {
+                    Console.Error.WriteLine("OpenH264 initialized.");
+                }
+            }
+            catch (Exception ex)
+            {
+                Console.Error.WriteLine($"OpenH264 failed to initialize. {ex}");
+            }
         }
     }
 }

--- a/src/FM.LiveSwitch.Connect/ReceiveOptions.cs
+++ b/src/FM.LiveSwitch.Connect/ReceiveOptions.cs
@@ -2,7 +2,7 @@
 
 namespace FM.LiveSwitch.Connect
 {
-    abstract class ReceiveOptions : Options, IReceiveOptions
+    abstract class ReceiveOptions : StreamOptions, IReceiveOptions
     {
         [Option("connection-id", Required = true, HelpText = "The remote connection ID or 'mcu'.")]
         public string ConnectionId { get; set; }

--- a/src/FM.LiveSwitch.Connect/Renderer.cs
+++ b/src/FM.LiveSwitch.Connect/Renderer.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Linq;
 using System.Threading.Tasks;
 
 namespace FM.LiveSwitch.Connect
@@ -125,9 +124,9 @@ namespace FM.LiveSwitch.Connect
         private AudioTrack CreateAudioTrack()
         {
             var tracks = new List<AudioTrack>();
-            foreach (var codec in ((AudioCodec[])Enum.GetValues(typeof(AudioCodec))).Where(x => x != AudioCodec.Any))
+            foreach (var encoding in (AudioEncoding[])Enum.GetValues(typeof(AudioEncoding)))
             {
-                tracks.Add(CreateAudioTrack(codec));
+                tracks.Add(CreateAudioTrack(encoding));
             }
             return new AudioTrack(tracks.ToArray());
         }
@@ -135,21 +134,21 @@ namespace FM.LiveSwitch.Connect
         private VideoTrack CreateVideoTrack()
         {
             var tracks = new List<VideoTrack>();
-            foreach (var codec in ((VideoCodec[])Enum.GetValues(typeof(VideoCodec))).Where(x => x != VideoCodec.Any))
+            foreach (var encoding in (VideoEncoding[])Enum.GetValues(typeof(VideoEncoding)))
             {
-                if (Options.DisableOpenH264 && codec == VideoCodec.H264)
+                if (Options.DisableOpenH264 && encoding == VideoEncoding.H264)
                 {
                     continue;
                 }
-                tracks.Add(CreateVideoTrack(codec));
+                tracks.Add(CreateVideoTrack(encoding));
             }
             return new VideoTrack(tracks.ToArray());
         }
 
-        private AudioTrack CreateAudioTrack(AudioCodec codec)
+        private AudioTrack CreateAudioTrack(AudioEncoding encoding)
         {
-            var depacketizer = codec.CreateDepacketizer();
-            var decoder = codec.CreateDecoder();
+            var depacketizer = encoding.CreateDepacketizer();
+            var decoder = encoding.CreateDecoder();
             var converter = new SoundConverter(new AudioConfig(Options.AudioClockRate, Options.AudioChannelCount));
             var reframer = new SoundReframer(new AudioConfig(Options.AudioClockRate, Options.AudioChannelCount), Options.AudioFrameDuration);
             var sink = new NamedPipeAudioSink(Options.AudioPipe, Options.Client);
@@ -160,10 +159,10 @@ namespace FM.LiveSwitch.Connect
             return new AudioTrack(depacketizer).Next(decoder).Next(converter).Next(reframer).Next(sink);
         }
 
-        private VideoTrack CreateVideoTrack(VideoCodec codec)
+        private VideoTrack CreateVideoTrack(VideoEncoding encoding)
         {
-            var depacketizer = codec.CreateDepacketizer();
-            var decoder = codec.CreateDecoder();
+            var depacketizer = encoding.CreateDepacketizer();
+            var decoder = encoding.CreateDecoder();
             var converter = new Yuv.ImageConverter(Options.VideoFormat.CreateFormat());
             converter.OnProcessFrame += (frame) =>
             {

--- a/src/FM.LiveSwitch.Connect/RtpAudioSource.cs
+++ b/src/FM.LiveSwitch.Connect/RtpAudioSource.cs
@@ -29,14 +29,24 @@
 
         private void Initialize()
         {
-            _Reader.OnPacket += (payload, sequenceNumber, timestamp, marker) =>
+            _Reader.OnPacket += (packet) =>
             {
-                RaiseFrame(new AudioFrame(-1, new PacketizedAudioBuffer(payload, OutputFormat, new RtpPacketHeader()))
-                {
-                    SequenceNumber = sequenceNumber,
-                    Timestamp = timestamp
-                });
+                packet.Payload.LittleEndian = OutputFormat.LittleEndian;
+
+                RaisePacket(packet);
             };
+        }
+
+        private void RaisePacket(RtpPacket packet)
+        {
+            RaiseFrame(new AudioFrame(-1, new PacketizedAudioBuffer(packet.Payload, OutputFormat, new RtpPacketHeader
+            {
+                Marker = packet.Marker
+            }))
+            {
+                SequenceNumber = packet.SequenceNumber,
+                Timestamp = packet.Timestamp
+            });
         }
 
         protected override Future<object> DoStart()

--- a/src/FM.LiveSwitch.Connect/RtpPacket.cs
+++ b/src/FM.LiveSwitch.Connect/RtpPacket.cs
@@ -1,0 +1,18 @@
+﻿namespace FM.LiveSwitch.Connect
+{
+    class RtpPacket
+    {
+        public DataBuffer Payload { get; set; }
+        public long SequenceNumber { get; set; }
+        public long Timestamp { get; set; }
+        public bool Marker { get; set; }
+
+        public RtpPacket(DataBuffer payload, long sequenceNumber, long timestamp, bool marker)
+        {
+            Payload = payload;
+            SequenceNumber = sequenceNumber;
+            Timestamp = timestamp;
+            Marker = marker;
+        }
+    }
+}

--- a/src/FM.LiveSwitch.Connect/SendOptions.cs
+++ b/src/FM.LiveSwitch.Connect/SendOptions.cs
@@ -2,15 +2,28 @@
 
 namespace FM.LiveSwitch.Connect
 {
-    abstract class SendOptions : Options, ISendOptions
+    abstract class SendOptions : StreamOptions, ISendOptions
     {
         [Option("media-id", Required = false, HelpText = "The local media ID.")]
         public string MediaId { get; set; }
 
-        [Option("audio-bitrate", Required = false, Default = 32, HelpText = "The requested audio bitrate.")]
-        public int AudioBitrate { get; set; }
+        [Option("audio-bitrate", Required = false, HelpText = "The audio bitrate.")]
+        public int? AudioBitrate { get; set; }
 
-        [Option("video-bitrate", Required = false, Default = 1000, HelpText = "The requested video bitrate.")]
-        public int VideoBitrate { get; set; }
+        [Option("video-bitrate", Required = false, HelpText = "The video bitrate.")]
+        public int? VideoBitrate { get; set; }
+
+        [Option("video-width", Required = false, HelpText = "The video width, if known, for signalling.")]
+        public int? VideoWidth { get; set; }
+
+        [Option("video-height", Required = false, HelpText = "The video height, if known, for signalling.")]
+        public int? VideoHeight { get; set; }
+
+        [Option("video-frame-rate", Required = false, HelpText = "The video frame-rate, if known, for signalling.")]
+        public double? VideoFrameRate { get; set; }
+
+        public bool AudioTranscode { get; set; }
+
+        public bool VideoTranscode { get; set; }
     }
 }

--- a/src/FM.LiveSwitch.Connect/ShellOptions.cs
+++ b/src/FM.LiveSwitch.Connect/ShellOptions.cs
@@ -3,17 +3,6 @@
 namespace FM.LiveSwitch.Connect
 {
     [Verb("shell", HelpText = "Starts an interactive shell.")]
-    class ShellOptions
-    {
-        public bool DisableOpenH264 { get; set; }
-
-        [Option("gateway-url", Required = true, HelpText = "The gateway URL.")]
-        public string GatewayUrl { get; set; }
-
-        [Option("application-id", Required = true, HelpText = "The application ID.")]
-        public string ApplicationId { get; set; }
-
-        [Option("shared-secret", Required = true, HelpText = "The shared secret for the application ID.")]
-        public string SharedSecret { get; set; }
-    }
+    class ShellOptions : Options
+    { }
 }

--- a/src/FM.LiveSwitch.Connect/StreamOptions.cs
+++ b/src/FM.LiveSwitch.Connect/StreamOptions.cs
@@ -1,0 +1,47 @@
+﻿using CommandLine;
+using System.Collections.Generic;
+
+namespace FM.LiveSwitch.Connect
+{
+    abstract class StreamOptions : Options, IConnectionOptions, IChannelOptions, IClientOptions
+    {
+        [Option("channel-id", Required = true, HelpText = "The channel ID.")]
+        public string ChannelId { get; set; }
+
+        [Option("data-channel-label", Required = false, HelpText = "The data channel label.")]
+        public string DataChannelLabel { get; set; }
+
+        [Option("user-id", Required = false, HelpText = "The local user ID.")]
+        public string UserId { get; set; }
+
+        [Option("user-alias", Required = false, HelpText = "The local user alias.")]
+        public string UserAlias { get; set; }
+
+        [Option("device-id", Required = false, HelpText = "The local device ID.")]
+        public string DeviceId { get; set; }
+
+        [Option("device-alias", Required = false, HelpText = "The local device alias.")]
+        public string DeviceAlias { get; set; }
+
+        [Option("client-tag", Required = false, HelpText = "The local client tag.")]
+        public string ClientTag { get; set; }
+
+        [Option("client-roles", Required = false, HelpText = "The local client roles.")]
+        public IEnumerable<string> ClientRoles { get; set; }
+
+        [Option("connection-tag", Required = false, HelpText = "The local connection tag.")]
+        public string ConnectionTag { get; set; }
+
+        [Option("no-audio", Required = false, HelpText = "Do not process audio.")]
+        public bool NoAudio { get; set; }
+
+        [Option("no-video", Required = false, HelpText = "Do not process video.")]
+        public bool NoVideo { get; set; }
+
+        [Option("audio-codec", Required = false, Default = AudioCodec.Any, HelpText = "The audio codec to negotiate with LiveSwitch.")]
+        public AudioCodec AudioCodec { get; set; }
+
+        [Option("video-codec", Required = false, Default = VideoCodec.Any, HelpText = "The video codec to negotiate with LiveSwitch.")]
+        public VideoCodec VideoCodec { get; set; }
+    }
+}

--- a/src/FM.LiveSwitch.Connect/VideoCodecExtensions.cs
+++ b/src/FM.LiveSwitch.Connect/VideoCodecExtensions.cs
@@ -4,84 +4,22 @@ namespace FM.LiveSwitch.Connect
 {
     static class VideoCodecExtensions
     {
-        public static VideoEncoder CreateEncoder(this VideoCodec codec)
+        public static VideoEncoding ToEncoding(this VideoCodec codec)
         {
             switch (codec)
             {
                 case VideoCodec.VP8:
-                    return new Vp8.Encoder();
+                    return VideoEncoding.VP8;
                 case VideoCodec.VP9:
-                    return new Vp9.Encoder();
+                    return VideoEncoding.VP9;
                 case VideoCodec.H264:
-                    return new OpenH264.Encoder();
+                    return VideoEncoding.H264;
+                case VideoCodec.Any:
+                    throw new Exception("Cannot convert 'any' codec to encoding.");
                 default:
-                    throw new Exception("Unknown video codec.");
+                    throw new Exception("Unknown video encoding.");
             }
         }
 
-        public static VideoDecoder CreateDecoder(this VideoCodec codec)
-        {
-            switch (codec)
-            {
-                case VideoCodec.VP8:
-                    return new Vp8.Decoder();
-                case VideoCodec.VP9:
-                    return new Vp9.Decoder();
-                case VideoCodec.H264:
-                    return new OpenH264.Decoder();
-                default:
-                    throw new Exception("Unknown video codec.");
-            }
-        }
-
-        public static VideoPacketizer CreatePacketizer(this VideoCodec codec)
-        {
-            switch (codec)
-            {
-                case VideoCodec.VP8:
-                    return new Vp8.Packetizer();
-                case VideoCodec.VP9:
-                    return new Vp9.Packetizer();
-                case VideoCodec.H264:
-                    return new H264.Packetizer();
-                default:
-                    throw new Exception("Unknown video codec.");
-            }
-        }
-
-        public static VideoPipe CreateDepacketizer(this VideoCodec codec)
-        {
-            switch (codec)
-            {
-                case VideoCodec.VP8:
-                    return new Vp8.Depacketizer();
-                case VideoCodec.VP9:
-                    return new Vp9.Depacketizer();
-                case VideoCodec.H264:
-                    return new H264.Depacketizer();
-                default:
-                    throw new Exception("Unknown video codec.");
-            }
-        }
-
-        public static NullVideoSink CreateNullSink(this VideoCodec codec, bool isPacketized)
-        {
-            return new NullVideoSink(CreateFormat(codec, isPacketized));
-        }
-
-        public static VideoFormat CreateFormat(this VideoCodec codec, bool isPacketized = false)
-        {
-            switch (codec)
-            {
-                case VideoCodec.VP8:
-                    return new Vp8.Format() { IsPacketized = isPacketized };
-                case VideoCodec.VP9:
-                    return new Vp9.Format() { IsPacketized = isPacketized };
-                case VideoCodec.H264:
-                    return new H264.Format(H264.ProfileLevelId.Default, H264.PacketizationMode.Default) { IsPacketized = isPacketized };
-                default:
-                    throw new Exception("Unknown video codec.");
-            }
-        }
     }
 }

--- a/src/FM.LiveSwitch.Connect/VideoEncoding.cs
+++ b/src/FM.LiveSwitch.Connect/VideoEncoding.cs
@@ -1,0 +1,9 @@
+﻿namespace FM.LiveSwitch.Connect
+{
+    enum VideoEncoding
+    {
+        VP8,
+        VP9,
+        H264
+    }
+}

--- a/src/FM.LiveSwitch.Connect/VideoEncodingExtensions.cs
+++ b/src/FM.LiveSwitch.Connect/VideoEncodingExtensions.cs
@@ -1,0 +1,102 @@
+﻿using System;
+
+namespace FM.LiveSwitch.Connect
+{
+    static class VideoEncodingExtensions
+    {
+        public static VideoCodec ToCodec(this VideoEncoding encoding)
+        {
+            switch (encoding)
+            {
+                case VideoEncoding.VP8:
+                    return VideoCodec.VP8;
+                case VideoEncoding.VP9:
+                    return VideoCodec.VP9;
+                case VideoEncoding.H264:
+                    return VideoCodec.H264;
+                default:
+                    throw new Exception("Unknown video encoding.");
+            }
+        }
+
+        public static VideoEncoder CreateEncoder(this VideoEncoding encoding)
+        {
+            switch (encoding)
+            {
+                case VideoEncoding.VP8:
+                    return new Vp8.Encoder();
+                case VideoEncoding.VP9:
+                    return new Vp9.Encoder();
+                case VideoEncoding.H264:
+                    return new OpenH264.Encoder();
+                default:
+                    throw new Exception("Unknown video encoding.");
+            }
+        }
+
+        public static VideoDecoder CreateDecoder(this VideoEncoding encoding)
+        {
+            switch (encoding)
+            {
+                case VideoEncoding.VP8:
+                    return new Vp8.Decoder();
+                case VideoEncoding.VP9:
+                    return new Vp9.Decoder();
+                case VideoEncoding.H264:
+                    return new OpenH264.Decoder();
+                default:
+                    throw new Exception("Unknown video encoding.");
+            }
+        }
+
+        public static VideoPacketizer CreatePacketizer(this VideoEncoding encoding)
+        {
+            switch (encoding)
+            {
+                case VideoEncoding.VP8:
+                    return new Vp8.Packetizer();
+                case VideoEncoding.VP9:
+                    return new Vp9.Packetizer();
+                case VideoEncoding.H264:
+                    return new H264.Packetizer(H264.PacketizationMode.Default);
+                default:
+                    throw new Exception("Unknown video encoding.");
+            }
+        }
+
+        public static VideoPipe CreateDepacketizer(this VideoEncoding encoding)
+        {
+            switch (encoding)
+            {
+                case VideoEncoding.VP8:
+                    return new Vp8.Depacketizer();
+                case VideoEncoding.VP9:
+                    return new Vp9.Depacketizer();
+                case VideoEncoding.H264:
+                    return new H264.Depacketizer(H264.PacketizationMode.Default);
+                default:
+                    throw new Exception("Unknown video encoding.");
+            }
+        }
+
+        public static NullVideoSink CreateNullSink(this VideoEncoding encoding, bool isPacketized)
+        {
+            return new NullVideoSink(CreateFormat(encoding, isPacketized));
+        }
+
+        public static VideoFormat CreateFormat(this VideoEncoding encoding, bool isPacketized = false)
+        {
+            switch (encoding)
+            {
+                case VideoEncoding.VP8:
+                    return new Vp8.Format() { IsPacketized = isPacketized };
+                case VideoEncoding.VP9:
+                    return new Vp9.Format() { IsPacketized = isPacketized };
+                case VideoEncoding.H264:
+                    return new H264.Format(H264.ProfileLevelId.Default, H264.PacketizationMode.Default) { IsPacketized = isPacketized };
+                default:
+                    throw new Exception("Unknown video encoding.");
+            }
+        }
+    }
+}

--- a/src/FM.LiveSwitch.Connect/VideoFormatExtensions.cs
+++ b/src/FM.LiveSwitch.Connect/VideoFormatExtensions.cs
@@ -4,19 +4,19 @@ namespace FM.LiveSwitch.Connect
 {
     static class VideoFormatExtensions
     {
-        public static VideoCodec CreateCodec(this VideoFormat format)
+        public static VideoEncoding ToEncoding(this VideoFormat format)
         {
             if (format.Name == VideoFormat.Vp8Name)
             {
-                return VideoCodec.VP8;
+                return VideoEncoding.VP8;
             }
             if (format.Name == VideoFormat.Vp9Name)
             {
-                return VideoCodec.VP9;
+                return VideoEncoding.VP9;
             }
             if (format.Name == VideoFormat.H264Name)
             {
-                return VideoCodec.H264;
+                return VideoEncoding.H264;
             }
             throw new Exception("Unknown video format.");
         }


### PR DESCRIPTION
- Added `audio-encoding` and `video-encoding` options to `ffcapture`, used if the input stream is compressed (i.e. `audio-mode` or `video-mode` is set to `noencode` or `ffencode`) and we wish to declare the encoding separately from the negotiated `audio-codec` or `video-codec` on the upstream. Setting this value implies transcoding.
- Added `video-width`, `video-height`, and `video-frame-rate` options for all send verbs (previously only available for `fake` and `capture` verbs) to allow signalling of input stream resolution and frame-rate to remote LiveSwitch clients.
- Added `log-level` option for all verbs to control log output level from LiveSwitch.
- Updated LiveSwitch SDK to current release (1.9.3).
- Updated H.264 handling when `video-mode` is `noencode` to parse parameter sets from `ffmpeg` SDP if the remote stream sends SPS/PPS information out-of-band (e.g. RTMP).
- Updated the RTP reader to use a dispatch queue to speed up network access and avoid dropped packets.
- Updated `log` verb to use `encoding` instead of `codec`. This resolves an issue with the semantics of the `codec` parameter, which indicates a desired `encoding` and can be used to indicate `any`, which only makes sense prior to negotiation.
- Fixed a bug where `NamedPipeAudioSource` did not set the `LittleEndian` flag, resulting in a flood of log messages related about automatically switching from big endian to little endian on PCM audio frames.