### PR TITLE
Receiver enhancements

### DIFF
--- a/src/FM.LiveSwitch.Connect/Capturer.cs
+++ b/src/FM.LiveSwitch.Connect/Capturer.cs
@@ -11,12 +11,12 @@ namespace FM.LiveSwitch.Connect
 
         public Task<int> Capture()
         {
-            if (Options.AudioPipe == null && Options.VideoPipe == null)
+            if (Options.AudioPipe == null)
             {
-                Console.Error.WriteLine("--audio-pipe and/or --video-pipe must be specified.");
-                return Task.FromResult(1);
+                Console.Error.WriteLine("Setting --no-audio to true because --audio-pipe is not specified.");
+                Options.NoAudio = true;
             }
-            if (Options.AudioPipe != null)
+            else
             {
                 if (Options.AudioClockRate % 8000 != 0)
                 {
@@ -54,7 +54,12 @@ namespace FM.LiveSwitch.Connect
                     return Task.FromResult(1);
                 }
             }
-            if (Options.VideoPipe != null)
+            if (Options.VideoPipe == null)
+            {
+                Console.Error.WriteLine("Setting --no-video to true because --video-pipe is not specified.");
+                Options.NoVideo = true;
+            }
+            else
             {
                 if (!Options.VideoWidth.HasValue || Options.VideoWidth == 0)
                 {

--- a/src/FM.LiveSwitch.Connect/DataSink.cs
+++ b/src/FM.LiveSwitch.Connect/DataSink.cs
@@ -1,0 +1,19 @@
+﻿using System;
+
+namespace FM.LiveSwitch.Connect
+{
+    class DataSink
+    {
+        public void ProcessReceive(DataChannelReceiveArgs args)
+        {
+            if (args.DataString != null)
+            {
+                Console.WriteLine(args.DataString);
+            }
+            else
+            {
+                Console.Error.WriteLine($"Cannot write binary message from data channel: {args.DataBytes.ToHexString()}");
+            }
+        }
+    }
+}

--- a/src/FM.LiveSwitch.Connect/FFCaptureOptions.cs
+++ b/src/FM.LiveSwitch.Connect/FFCaptureOptions.cs
@@ -20,7 +20,7 @@ namespace FM.LiveSwitch.Connect
         [Option("video-encoding", Required = false, HelpText = "The video encoding of the input stream, if different from video-codec. Enables transcoding if video-mode is noencode or ffencode.")]
         public VideoEncoding? VideoEncoding { get; set; }
 
-        [Option("ffencode-keyframe-interval", Required = false, Default = 30, HelpText = "The keyframe interval for video. Only used if video-mode is ffencode.")]
-        public int FFEncodeKeyFrameInterval { get; set; }
+        [Option("keyframe-interval", Required = false, Default = 60, HelpText = "The keyframe interval for video, in frames. Only used if video-mode is ffencode.")]
+        public int KeyFrameInterval { get; set; }
     }
 }

--- a/src/FM.LiveSwitch.Connect/FFCapturer.cs
+++ b/src/FM.LiveSwitch.Connect/FFCapturer.cs
@@ -79,7 +79,7 @@ namespace FM.LiveSwitch.Connect
                 var source = new PcmNamedPipeAudioSource($"ffcapture_pcm_{ShortId()}");
                 source.OnPipeConnected += () =>
                 {
-                    Console.Error.WriteLine("Video pipe connected.");
+                    Console.Error.WriteLine("Audio pipe connected.");
                 };
                 return source;
             }
@@ -107,6 +107,8 @@ namespace FM.LiveSwitch.Connect
         }
 
         private Process FFmpeg;
+        private string H264SdpFileName;
+
         private const int G722PacketSize = 320 + 12;
         private const int PcmuPacketSize = 320 + 12;
         private const int PcmaPacketSize = 320 + 12;
@@ -220,7 +222,6 @@ namespace FM.LiveSwitch.Connect
             }
 
             var readH264ParameterSets = false;
-            var sdpFileName = null as string;
             if (VideoSource != null)
             {
                 args.Add($"-map 0:v:0");
@@ -249,10 +250,10 @@ namespace FM.LiveSwitch.Connect
                         {
                             readH264ParameterSets = true;
                             source.NeedsParameterSets = true;
-                            sdpFileName = $"{VideoSource.Id}.sdp";
+                            H264SdpFileName = $"h264_{Utility.GenerateId()}.sdp";
                             args.AddRange(new[]
                             {
-                                $"-sdp_file {sdpFileName}",
+                                $"-sdp_file {H264SdpFileName}",
                             });
                         }
                     }
@@ -268,7 +269,7 @@ namespace FM.LiveSwitch.Connect
                                 $"-speed 16",
                                 $"-crf 10",
                                 $"-b:v {Options.VideoBitrate}k",
-                                $"-g {Options.FFEncodeKeyFrameInterval}",
+                                $"-g {Options.KeyFrameInterval}",
                             });
                         }
                         else if (RtpVideoFormat.IsVp9)
@@ -283,7 +284,7 @@ namespace FM.LiveSwitch.Connect
                                 $"-quality realtime",
                                 $"-speed 16",
                                 $"-b:v {Options.VideoBitrate}k -maxrate {Options.VideoBitrate}k",
-                                $"-g {Options.FFEncodeKeyFrameInterval}",
+                                $"-g {Options.KeyFrameInterval}",
                             });
                         }
                         else if (RtpVideoFormat.IsH264)
@@ -296,7 +297,7 @@ namespace FM.LiveSwitch.Connect
                                 $"-pix_fmt yuv420p",
                                 $"-tune zerolatency",
                                 $"-b:v {Options.VideoBitrate}k",
-                                $"-g {Options.FFEncodeKeyFrameInterval} -keyint_min {Options.FFEncodeKeyFrameInterval}",
+                                $"-g {Options.KeyFrameInterval} -keyint_min {Options.KeyFrameInterval}",
                             });
                         }
                         else
@@ -328,7 +329,7 @@ namespace FM.LiveSwitch.Connect
 
             if (readH264ParameterSets)
             {
-                ProcessParameterSets(sdpFileName);
+                ProcessParameterSets();
             }
 
             return ready;
@@ -342,21 +343,30 @@ namespace FM.LiveSwitch.Connect
                 FFmpeg.WaitForExit();
             }
 
+            try
+            {
+                File.Delete(H264SdpFileName);
+            }
+            catch (Exception ex)
+            {
+                Console.Error.WriteLine($"H.264 SDP output file could not be deleted. {ex}");
+            }
+
             return base.Unready();
         }
 
-        private void ProcessParameterSets(string sdpFileName)
+        private void ProcessParameterSets()
         {
             // wait for SDP file to exist
             var cancelTimeout = new CancellationTokenSource();
             var timeout = Task.Delay(5000, cancelTimeout.Token);
-            while (!File.Exists(sdpFileName) && !timeout.IsCompletedSuccessfully)
+            while (!File.Exists(H264SdpFileName) && !timeout.IsCompletedSuccessfully)
             {
                 Thread.Sleep(10);
             }
             if (timeout.IsCompletedSuccessfully)
             {
-                throw new Exception("File containing H.264 parameter sets was not found.");
+                throw new Exception("H.264 SDP output file was not found.");
             }
             cancelTimeout.Cancel();
 
@@ -369,7 +379,7 @@ namespace FM.LiveSwitch.Connect
             {
                 try
                 {
-                    sdp = File.ReadAllText(sdpFileName);
+                    sdp = File.ReadAllText(H264SdpFileName);
                 }
                 catch (Exception ex)
                 {
@@ -378,7 +388,7 @@ namespace FM.LiveSwitch.Connect
             }
             if (timeout.IsCompletedSuccessfully)
             {
-                throw new Exception("File containing H.264 parameter sets could not be read.", readException);
+                throw new Exception("H.264 SDP output file could not be read.", readException);
             }
             cancelTimeout.Cancel();
 
@@ -396,19 +406,19 @@ namespace FM.LiveSwitch.Connect
             var sdpMessage = Sdp.Message.Parse(sdp);
             if (sdpMessage == null)
             {
-                throw new Exception("File containing H.264 parameter sets could not be parsed.");
+                throw new Exception("H.264 SDP output file could not be parsed.");
             }
 
             var sdpMediaDescription = sdpMessage.MediaDescriptions.FirstOrDefault();
             if (sdpMediaDescription?.Media?.MediaType != Sdp.MediaType.Video)
             {
-                throw new Exception("File containing H.264 parameter sets is missing video description.");
+                throw new Exception("H.264 SDP output file is missing video description.");
             }
 
             var rtpMapAttribute = sdpMediaDescription.GetRtpMapAttributes()?.FirstOrDefault();
             if (rtpMapAttribute?.FormatName != VideoFormat.H264Name)
             {
-                throw new Exception("File containing H.264 parameter sets is missing H.264 RTP map attribute.");
+                throw new Exception("H.264 SDP output file is missing H.264 RTP map attribute.");
             }
 
             var formatSpecificParametersString = rtpMapAttribute.RelatedFormatParametersAttribute?.FormatSpecificParameters;
@@ -426,15 +436,6 @@ namespace FM.LiveSwitch.Connect
 
                     ((RtpVideoSource)VideoSource).ParameterSets = parameterSets;
                 }
-            }
-
-            try
-            {
-                File.Delete(sdpFileName);
-            }
-            catch (Exception ex)
-            {
-                throw new Exception("File containing H.264 parameter sets could not be deleted.", ex);
             }
         }
 

--- a/src/FM.LiveSwitch.Connect/FFRenderMode.cs
+++ b/src/FM.LiveSwitch.Connect/FFRenderMode.cs
@@ -1,0 +1,8 @@
+﻿namespace FM.LiveSwitch.Connect
+{
+    enum FFRenderMode
+    {
+        LSDecode,
+        NoDecode
+    }
+}

--- a/src/FM.LiveSwitch.Connect/FFRenderOptions.cs
+++ b/src/FM.LiveSwitch.Connect/FFRenderOptions.cs
@@ -7,5 +7,20 @@ namespace FM.LiveSwitch.Connect
     {
         [Option("output-args", Required = true, HelpText = "The FFmpeg output arguments.")]
         public string OutputArgs { get; set; }
+
+        [Option("audio-mode", Required = false, Default = FFRenderMode.LSDecode, HelpText = "Where audio is decoded.")]
+        public FFRenderMode AudioMode { get; set; }
+
+        [Option("video-mode", Required = false, Default = FFRenderMode.LSDecode, HelpText = "Where video is decoded.")]
+        public FFRenderMode VideoMode { get; set; }
+
+        [Option("audio-encoding", Required = false, HelpText = "The audio encoding of the output stream, if different from audio-codec. Enables transcoding if audio-mode is nodecode or ffdecode.")]
+        public AudioEncoding? AudioEncoding { get; set; }
+
+        [Option("video-encoding", Required = false, HelpText = "The video encoding of the output stream, if different from video-codec. Enables transcoding if video-mode is nodecode or ffdecode.")]
+        public VideoEncoding? VideoEncoding { get; set; }
+
+        [Option("keyframe-interval", Required = false, Default = 60, HelpText = "The keyframe interval for video, in frames. Only used if video-mode is nodecode.")]
+        public int KeyFrameInterval { get; set; }
     }
 }

--- a/src/FM.LiveSwitch.Connect/FFRenderer.cs
+++ b/src/FM.LiveSwitch.Connect/FFRenderer.cs
@@ -158,42 +158,18 @@ namespace FM.LiveSwitch.Connect
                     {
                         sdpMediaDescription.AddMediaAttribute(new Sdp.Rtp.MapAttribute(sink.PayloadType, AudioFormat.OpusName, Opus.Format.DefaultClockRate, Opus.Format.DefaultChannelCount.ToString()));
                         sdpMediaDescription.AddMediaAttribute(new Sdp.FormatParametersAttribute(sink.PayloadType, "useinbandfec=1"));
-                        args.AddRange(new[]
-                        {
-                            $"-ar {config.ClockRate}",
-                            $"-ac {config.ChannelCount}",
-                            $"-c libopus",
-                        });
                     }
                     else if (RtpAudioFormat.IsG722)
                     {
                         sdpMediaDescription.AddMediaAttribute(new Sdp.Rtp.MapAttribute(sink.PayloadType, AudioFormat.G722Name, G722.Format.DefaultClockRate, G722.Format.DefaultChannelCount.ToString()));
-                        args.AddRange(new[]
-                        {
-                            $"-ar 16000",
-                            $"-ac 1",
-                            $"-c g722",
-                        });
                     }
                     else if (RtpAudioFormat.IsPcmu)
                     {
                         sdpMediaDescription.AddMediaAttribute(new Sdp.Rtp.MapAttribute(sink.PayloadType, AudioFormat.PcmuName, G711.Format.DefaultClockRate, G711.Format.DefaultChannelCount.ToString()));
-                        args.AddRange(new[]
-                        {
-                            $"-ar 8000",
-                            $"-ac 1",
-                            $"-c pcm_mulaw",
-                        });
                     }
                     else if (RtpAudioFormat.IsPcma)
                     {
                         sdpMediaDescription.AddMediaAttribute(new Sdp.Rtp.MapAttribute(sink.PayloadType, AudioFormat.PcmaName, G711.Format.DefaultClockRate, G711.Format.DefaultChannelCount.ToString()));
-                        args.AddRange(new[]
-                        {
-                            $"-ar 8000",
-                            $"-ac 1",
-                            $"-c pcm_alaw",
-                        });
                     }
                     else
                     {
@@ -249,18 +225,15 @@ namespace FM.LiveSwitch.Connect
                     if (RtpVideoFormat.IsVp8)
                     {
                         sdpMediaDescription.AddMediaAttribute(new Sdp.Rtp.MapAttribute(sink.PayloadType, VideoFormat.Vp8Name, VideoFormat.DefaultClockRate));
-                        args.Add("-c vp8");
                     }
                     else if (RtpVideoFormat.IsVp9)
                     {
                         sdpMediaDescription.AddMediaAttribute(new Sdp.Rtp.MapAttribute(sink.PayloadType, VideoFormat.Vp9Name, VideoFormat.DefaultClockRate));
-                        args.Add("-c vp9");
                     }
                     else if (RtpVideoFormat.IsH264)
                     {
                         sdpMediaDescription.AddMediaAttribute(new Sdp.Rtp.MapAttribute(sink.PayloadType, VideoFormat.H264Name, VideoFormat.DefaultClockRate));
                         sdpMediaDescription.AddMediaAttribute(new Sdp.FormatParametersAttribute(sink.PayloadType, "profile-level-id=42001f;level-asymmetry-allowed=1;packetization-mode=1"));
-                        args.Add("-c h264");
                     }
                     else
                     {

--- a/src/FM.LiveSwitch.Connect/FFRenderer.cs
+++ b/src/FM.LiveSwitch.Connect/FFRenderer.cs
@@ -1,12 +1,37 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.IO;
 using System.Threading.Tasks;
 
 namespace FM.LiveSwitch.Connect
 {
-    class FFRenderer : Receiver<FFRenderOptions, NamedPipeAudioSink, NamedPipeVideoSink>
+    class FFRenderer : Receiver<FFRenderOptions, AudioSink, VideoSink>
     {
+        public AudioFormat RtpAudioFormat
+        {
+            get
+            {
+                if (Options.AudioEncoding.HasValue)
+                {
+                    return Options.AudioEncoding.Value.CreateFormat(true);
+                }
+                return AudioFormat;
+            }
+        }
+
+        public VideoFormat RtpVideoFormat
+        {
+            get
+            {
+                if (Options.VideoEncoding.HasValue)
+                {
+                    return Options.VideoEncoding.Value.CreateFormat(true);
+                }
+                return VideoFormat;
+            }
+        }
+
         public FFRenderer(FFRenderOptions options)
             : base(options)
         { }
@@ -18,152 +43,276 @@ namespace FM.LiveSwitch.Connect
 
         public Task<int> Render()
         {
+            if (!Options.NoAudio)
+            {
+                if (Options.AudioMode == FFRenderMode.NoDecode && Options.AudioCodec == AudioCodec.Any)
+                {
+                    Console.Error.WriteLine("--audio-codec must be set (not 'any') if --audio-mode is 'nodecode'.");
+                    return Task.FromResult(1);
+                }
+                if (Options.AudioEncoding.HasValue)
+                {
+                    Options.AudioTranscode = true;
+                }
+            }
+            if (!Options.NoVideo)
+            {
+                if (Options.VideoMode == FFRenderMode.NoDecode && Options.VideoCodec == VideoCodec.Any)
+                {
+                    Console.Error.WriteLine("--video-codec must be set (not 'any') if --video-mode is 'nodecode'.");
+                    return Task.FromResult(1);
+                }
+                if (Options.VideoEncoding.HasValue)
+                {
+                    Options.VideoTranscode = true;
+                }
+            }
             return Receive();
         }
 
-        protected override AudioStream CreateAudioStream(ConnectionInfo remoteConnectionInfo)
+        protected override AudioSink CreateAudioSink()
         {
-            if (Options.NoAudio || !remoteConnectionInfo.HasAudio)
+            if (Options.AudioMode == FFRenderMode.LSDecode)
             {
-                return null;
-            }
-
-            var track = CreateAudioTrack();
-            var stream = new AudioStream(null, track);
-            stream.OnStateChange += () =>
-            {
-                if (stream.State == StreamState.Closed ||
-                    stream.State == StreamState.Failed)
+                var sink = new PcmNamedPipeAudioSink($"ffrender_pcm_{ShortId()}");
+                sink.OnPipeConnected += () =>
                 {
-                    track.Destroy();
-                }
-            };
-            return stream;
-        }
-
-        protected override VideoStream CreateVideoStream(ConnectionInfo remoteConnectionInfo)
-        {
-            if (Options.NoVideo || !remoteConnectionInfo.HasVideo)
-            {
-                return null;
+                    Console.Error.WriteLine("Audio pipe connected.");
+                };
+                return sink;
             }
-
-            var track = CreateVideoTrack();
-            var stream = new VideoStream(null, track);
-            stream.OnStateChange += () =>
+            else
             {
-                if (stream.State == StreamState.Closed ||
-                    stream.State == StreamState.Failed)
+                return new RtpAudioSink(RtpAudioFormat)
                 {
-                    track.Destroy();
-                }
-            };
-            return stream;
-        }
-
-        private AudioTrack CreateAudioTrack()
-        {
-            var sink = new PcmNamedPipeAudioSink($"ffrender_pcm_{ShortId()}");
-            sink.OnPipeConnected += () =>
-            {
-                Console.Error.WriteLine("Audio pipe connected.");
-            };
-
-            var tracks = new List<AudioTrack>();
-            foreach (var encoding in (AudioEncoding[])Enum.GetValues(typeof(AudioEncoding)))
-            {
-                tracks.Add(CreateAudioTrack(encoding));
+                    Deactivated = true
+                };
             }
-            return new AudioTrack(tracks.ToArray()).Next(sink);
         }
 
-        private VideoTrack CreateVideoTrack()
+        protected override VideoSink CreateVideoSink()
         {
-            var sink = new Yuv4MpegNamedPipeVideoSink($"ffrender_i420_{ShortId()}");
-            sink.OnPipeConnected += () =>
+            if (Options.VideoMode == FFRenderMode.LSDecode)
             {
-                Console.Error.WriteLine("Video pipe connected.");
-            };
-
-            var tracks = new List<VideoTrack>();
-            foreach (var encoding in (VideoEncoding[])Enum.GetValues(typeof(VideoEncoding)))
-            {
-                if (Options.DisableOpenH264 && encoding == VideoEncoding.H264)
+                var sink = new Yuv4MpegNamedPipeVideoSink($"ffrender_i420_{ShortId()}");
+                sink.OnPipeConnected += () =>
                 {
-                    continue;
-                }
-                tracks.Add(CreateVideoTrack(encoding));
+                    Console.Error.WriteLine("Video pipe connected.");
+                };
+                return sink;
             }
-            return new VideoTrack(tracks.ToArray()).Next(sink);
-        }
-
-        private AudioTrack CreateAudioTrack(AudioEncoding encoding)
-        {
-            var depacketizer = encoding.CreateDepacketizer();
-            var decoder = encoding.CreateDecoder();
-            var converter = new SoundConverter(Opus.Format.DefaultConfig);
-            return new AudioTrack(depacketizer).Next(decoder).Next(converter);
-        }
-
-        private VideoTrack CreateVideoTrack(VideoEncoding encoding)
-        {
-            var depacketizer = encoding.CreateDepacketizer();
-            var decoder = encoding.CreateDecoder();
-            var converter = new Yuv.ImageConverter(VideoFormat.I420); //TODO: use matroska and remove this?
-            return new VideoTrack(depacketizer).Next(decoder).Next(converter);
+            else
+            {
+                return new RtpVideoSink(RtpVideoFormat)
+                {
+                    Deactivated = true,
+                    KeyFrameInterval = Options.KeyFrameInterval
+                };
+            }
         }
 
         private Process FFmpeg;
+        private string AudioSdpFileName;
+        private string VideoSdpFileName;
 
-        protected override void SinksReady(NamedPipeAudioSink[] audioSinks, NamedPipeVideoSink[] videoSinks)
+        protected override async Task Ready()
         {
-            base.SinksReady(audioSinks, videoSinks);
+            await base.Ready();
 
             var args = new List<string>
             {
                 "-y"
             };
 
-            if (audioSinks != null)
+            if (AudioSink != null)
             {
-                var audioSink = audioSinks[0];
-                var config = audioSink.Config;
-                args.AddRange(new[]
+                var config = AudioSink.Config;
+
+                if (Options.AudioMode == FFRenderMode.LSDecode)
                 {
-                    $"-f s16le",
-                    $"-ar {config.ClockRate}",
-                    $"-ac {config.ChannelCount}",
-                    $"-i {NamedPipe.GetOSPipeName(audioSink.PipeName)}",
-                });
+                    var sink = AudioSink as PcmNamedPipeAudioSink;
+
+                    args.AddRange(new[]
+                    {
+                        $"-guess_layout_max 0",
+                        $"-f s16le",
+                        $"-ar {config.ClockRate}",
+                        $"-ac {config.ChannelCount}",
+                        $"-i {NamedPipe.GetOSPipeName(sink.PipeName)}",
+                    });
+                }
+                else
+                {
+                    var sink = AudioSink as RtpAudioSink;
+
+                    args.Add("-protocol_whitelist file,crypto,udp,rtp");
+
+                    sink.IPAddress = "127.0.0.1";
+                    sink.Port = LockedRandomizer.Next(49162, 65536);
+                    sink.PayloadType = 96;
+
+                    var sdpMediaDescription = new Sdp.MediaDescription(new Sdp.Media(Sdp.MediaType.Audio, sink.Port, Sdp.Rtp.Media.RtpAvpTransportProtocol, sink.PayloadType.ToString()));
+                    sdpMediaDescription.AddMediaAttribute(new Sdp.SendReceiveAttribute());
+
+                    if (RtpAudioFormat.IsOpus)
+                    {
+                        sdpMediaDescription.AddMediaAttribute(new Sdp.Rtp.MapAttribute(sink.PayloadType, AudioFormat.OpusName, Opus.Format.DefaultClockRate, Opus.Format.DefaultChannelCount.ToString()));
+                        sdpMediaDescription.AddMediaAttribute(new Sdp.FormatParametersAttribute(sink.PayloadType, "useinbandfec=1"));
+                        args.AddRange(new[]
+                        {
+                            $"-ar {config.ClockRate}",
+                            $"-ac {config.ChannelCount}",
+                            $"-c libopus",
+                        });
+                    }
+                    else if (RtpAudioFormat.IsG722)
+                    {
+                        sdpMediaDescription.AddMediaAttribute(new Sdp.Rtp.MapAttribute(sink.PayloadType, AudioFormat.G722Name, G722.Format.DefaultClockRate, G722.Format.DefaultChannelCount.ToString()));
+                        args.AddRange(new[]
+                        {
+                            $"-ar 16000",
+                            $"-ac 1",
+                            $"-c g722",
+                        });
+                    }
+                    else if (RtpAudioFormat.IsPcmu)
+                    {
+                        sdpMediaDescription.AddMediaAttribute(new Sdp.Rtp.MapAttribute(sink.PayloadType, AudioFormat.PcmuName, G711.Format.DefaultClockRate, G711.Format.DefaultChannelCount.ToString()));
+                        args.AddRange(new[]
+                        {
+                            $"-ar 8000",
+                            $"-ac 1",
+                            $"-c pcm_mulaw",
+                        });
+                    }
+                    else if (RtpAudioFormat.IsPcma)
+                    {
+                        sdpMediaDescription.AddMediaAttribute(new Sdp.Rtp.MapAttribute(sink.PayloadType, AudioFormat.PcmaName, G711.Format.DefaultClockRate, G711.Format.DefaultChannelCount.ToString()));
+                        args.AddRange(new[]
+                        {
+                            $"-ar 8000",
+                            $"-ac 1",
+                            $"-c pcm_alaw",
+                        });
+                    }
+                    else
+                    {
+                        throw new Exception("Unknown audio encoding.");
+                    }
+
+                    var sdpMessage = new Sdp.Message(new Sdp.Origin("127.0.0.1"), "lsconnect")
+                    {
+                        ConnectionData = new Sdp.ConnectionData("127.0.0.1")
+                    };
+                    if (sdpMediaDescription != null)
+                    {
+                        sdpMessage.AddMediaDescription(sdpMediaDescription);
+                    }
+
+                    var sdp = sdpMessage.ToString();
+
+                    AudioSdpFileName = $"audio_{Utility.GenerateId()}.sdp";
+
+                    File.WriteAllText(AudioSdpFileName, sdp);
+
+                    Console.Error.WriteLine($"Audio SDP:{Environment.NewLine}{sdp}");
+
+                    args.Add($"-i {AudioSdpFileName}");
+                }
             }
 
-            if (videoSinks != null)
+            if (VideoSink != null)
             {
-                var videoSink = videoSinks[0];
-                args.AddRange(new[]
+                if (Options.VideoMode == FFRenderMode.LSDecode)
                 {
-                    $"-f yuv4mpegpipe",
-                    $"-i {NamedPipe.GetOSPipeName(videoSink.PipeName)}",
-                });
+                    var sink = VideoSink as Yuv4MpegNamedPipeVideoSink;
+
+                    args.AddRange(new[]
+                    {
+                        $"-f yuv4mpegpipe",
+                        $"-i {NamedPipe.GetOSPipeName(sink.PipeName)}",
+                    });
+                }
+                else
+                {
+                    var sink = VideoSink as RtpVideoSink;
+
+                    args.Add("-protocol_whitelist file,crypto,udp,rtp");
+
+                    sink.IPAddress = "127.0.0.1";
+                    sink.Port = LockedRandomizer.Next(49162, 65536);
+                    sink.PayloadType = 97;
+
+                    var sdpMediaDescription = new Sdp.MediaDescription(new Sdp.Media(Sdp.MediaType.Video, sink.Port, Sdp.Rtp.Media.RtpAvpTransportProtocol, sink.PayloadType.ToString()));
+                    sdpMediaDescription.AddMediaAttribute(new Sdp.SendReceiveAttribute());
+
+                    if (RtpVideoFormat.IsVp8)
+                    {
+                        sdpMediaDescription.AddMediaAttribute(new Sdp.Rtp.MapAttribute(sink.PayloadType, VideoFormat.Vp8Name, VideoFormat.DefaultClockRate));
+                        args.Add("-c vp8");
+                    }
+                    else if (RtpVideoFormat.IsVp9)
+                    {
+                        sdpMediaDescription.AddMediaAttribute(new Sdp.Rtp.MapAttribute(sink.PayloadType, VideoFormat.Vp9Name, VideoFormat.DefaultClockRate));
+                        args.Add("-c vp9");
+                    }
+                    else if (RtpVideoFormat.IsH264)
+                    {
+                        sdpMediaDescription.AddMediaAttribute(new Sdp.Rtp.MapAttribute(sink.PayloadType, VideoFormat.H264Name, VideoFormat.DefaultClockRate));
+                        sdpMediaDescription.AddMediaAttribute(new Sdp.FormatParametersAttribute(sink.PayloadType, "profile-level-id=42001f;level-asymmetry-allowed=1;packetization-mode=1"));
+                        args.Add("-c h264");
+                    }
+                    else
+                    {
+                        throw new Exception("Unknown video format.");
+                    }
+
+                    var sdpMessage = new Sdp.Message(new Sdp.Origin("127.0.0.1"), "lsconnect")
+                    {
+                        ConnectionData = new Sdp.ConnectionData("127.0.0.1")
+                    };
+                    if (sdpMediaDescription != null)
+                    {
+                        sdpMessage.AddMediaDescription(sdpMediaDescription);
+                    }
+
+                    var sdp = sdpMessage.ToString();
+
+                    VideoSdpFileName = $"video_{Utility.GenerateId()}.sdp";
+
+                    File.WriteAllText(VideoSdpFileName, sdp);
+
+                    Console.Error.WriteLine($"Video SDP:{Environment.NewLine}{sdp}");
+
+                    args.Add($"-i {VideoSdpFileName}");
+                }
             }
 
             args.Add(Options.OutputArgs);
 
             FFmpeg = FFUtility.FFmpeg(string.Join(" ", args));
-        }
 
-        protected override void SinksUnready(NamedPipeAudioSink[] audioSinks, NamedPipeVideoSink[] videoSinks)
-        {
-            if (audioSinks != null)
+            if (AudioSink != null)
             {
-                var audioSink = audioSinks[0];
-                audioSink.Deactivated = true;
+                AudioSink.Deactivated = false;
             }
 
-            if (videoSinks != null)
+            if (VideoSink != null)
             {
-                var videoSink = videoSinks[0];
-                videoSink.Deactivated = true;
+                VideoSink.Deactivated = false;
+            }
+        }
+
+        protected override Task Unready()
+        {
+            if (AudioSink != null)
+            {
+                AudioSink.Deactivated = true;
+            }
+
+            if (VideoSink != null)
+            {
+                VideoSink.Deactivated = true;
             }
 
             if (FFmpeg != null)
@@ -172,7 +321,31 @@ namespace FM.LiveSwitch.Connect
                 FFmpeg.WaitForExit();
             }
 
-            base.SinksUnready(audioSinks, videoSinks);
+            if (AudioSdpFileName != null)
+            {
+                try
+                {
+                    File.Delete(AudioSdpFileName);
+                }
+                catch (Exception ex)
+                {
+                    Console.Error.WriteLine($"Audio SDP input file could not be deleted. {ex}");
+                }
+            }
+
+            if (VideoSdpFileName != null)
+            {
+                try
+                {
+                    File.Delete(VideoSdpFileName);
+                }
+                catch (Exception ex)
+                {
+                    Console.Error.WriteLine($"Video SDP input file could not be deleted. {ex}");
+                }
+            }
+
+            return base.Unready();
         }
     }
 }

--- a/src/FM.LiveSwitch.Connect/IReceiveOptions.cs
+++ b/src/FM.LiveSwitch.Connect/IReceiveOptions.cs
@@ -3,5 +3,13 @@
     interface IReceiveOptions : IConnectionOptions, IChannelOptions, IClientOptions
     {
         string ConnectionId { get; set; }
+
+        bool AudioTranscode { get; }
+
+        bool VideoTranscode { get; }
+
+        int? AudioBitrate { get; }
+
+        int? VideoBitrate { get; }
     }
 }

--- a/src/FM.LiveSwitch.Connect/PcmNamedPipeAudioSink.cs
+++ b/src/FM.LiveSwitch.Connect/PcmNamedPipeAudioSink.cs
@@ -8,7 +8,7 @@
         }
 
         public PcmNamedPipeAudioSink(string pipeName)
-            : base(pipeName)
+            : base(pipeName, false, new Pcm.Format(Opus.Format.DefaultConfig))
         { }
     }
 }

--- a/src/FM.LiveSwitch.Connect/Player.cs
+++ b/src/FM.LiveSwitch.Connect/Player.cs
@@ -11,10 +11,15 @@ namespace FM.LiveSwitch.Connect
 
         public Task<int> Play()
         {
-            if (Options.AudioPath == null && Options.VideoPath == null)
+            if (Options.AudioPath == null)
             {
-                Console.Error.WriteLine("--audio-path and/or --video-path must be specified.");
-                return Task.FromResult(1);
+                Console.Error.WriteLine("Setting --no-audio to true because --audio-path is not specified.");
+                Options.NoAudio = true;
+            }
+            if (Options.VideoPath == null)
+            {
+                Console.Error.WriteLine("Setting --no-video to true because --video-path is not specified.");
+                Options.NoVideo = true;
             }
             return Send();
         }

--- a/src/FM.LiveSwitch.Connect/ReceiveOptions.cs
+++ b/src/FM.LiveSwitch.Connect/ReceiveOptions.cs
@@ -6,5 +6,15 @@ namespace FM.LiveSwitch.Connect
     {
         [Option("connection-id", Required = true, HelpText = "The remote connection ID or 'mcu'.")]
         public string ConnectionId { get; set; }
+
+        [Option("audio-bitrate", Required = false, HelpText = "The audio bitrate.")]
+        public int? AudioBitrate { get; set; }
+
+        [Option("video-bitrate", Required = false, HelpText = "The video bitrate.")]
+        public int? VideoBitrate { get; set; }
+
+        public bool AudioTranscode { get; set; }
+
+        public bool VideoTranscode { get; set; }
     }
 }

--- a/src/FM.LiveSwitch.Connect/Receiver.cs
+++ b/src/FM.LiveSwitch.Connect/Receiver.cs
@@ -1,4 +1,5 @@
 ﻿using FM.LiveSwitch;
+using FM.LiveSwitch.Yuv;
 using System;
 using System.Linq;
 using System.Threading.Tasks;
@@ -11,6 +12,49 @@ namespace FM.LiveSwitch.Connect
         where TVideoSink : VideoSink
     {
         public TOptions Options { get; private set; }
+
+        protected AudioStream AudioStream { get; private set; }
+        protected VideoStream VideoStream { get; private set; }
+        protected DataStream DataStream { get; private set; }
+        protected DataChannel DataChannel { get; private set; }
+
+        protected AudioFormat AudioFormat { get; private set; }
+        protected VideoFormat VideoFormat { get; private set; }
+
+        protected TAudioSink AudioSink { get; private set; }
+        protected TVideoSink VideoSink { get; private set; }
+        protected DataSink DataSink { get; private set; }
+
+        protected AudioPacketizer AudioPacketizer { get; private set; }
+        protected VideoPacketizer VideoPacketizer { get; private set; }
+
+        protected AudioEncoder AudioEncoder { get; private set; }
+        protected VideoEncoder VideoEncoder { get; private set; }
+
+        protected ResetAudioPipe ResetAudioPipe { get; private set; }
+        protected ResetVideoPipe ResetVideoPipe { get; private set; }
+
+        protected SoundConverter AudioConverter { get; private set; }
+        protected ImageConverter VideoConverter { get; private set; }
+
+        protected SoundReframer AudioReframer { get; private set; }
+
+        protected AudioDecoder AudioDecoder { get; private set; }
+        protected VideoDecoder VideoDecoder { get; private set; }
+
+        protected AudioDepacketizer AudioDepacketizer { get; private set; }
+        protected VideoPipe VideoDepacketizer { get; private set; }
+
+        protected Client Client { get; private set; }
+        protected Channel Channel { get; private set; }
+        protected ManagedConnection Connection { get; private set; }
+
+        protected ConnectionInfo RemoteConnectionInfo { get; private set; }
+
+        private AudioPipe[] AudioPipes;
+        private VideoPipe[] VideoPipes;
+
+        private Task Disconnected;
 
         public Receiver(TOptions options)
         {
@@ -27,96 +71,36 @@ namespace FM.LiveSwitch.Connect
 
             try
             {
-                var client = Options.CreateClient();
+                Client = Options.CreateClient();
 
-                Console.Error.WriteLine($"{GetType().Name} client '{client.Id}' created:{Environment.NewLine}{Descriptor.Format(client.GetDescriptors())}");
+                Console.Error.WriteLine($"{GetType().Name} client created:{Environment.NewLine}{Descriptor.Format(Client.GetDescriptors())}");
 
-                await client.Register(Options);
+                await Client.Register(Options);
                 try
                 {
-                    var channel = await client.Join(Options);
+                    Channel = await Client.Join(Options);
                     try
                     {
-                        // wait up to 15 seconds to connect
-                        var timeout = Task.Delay(15000);
-                        var audioSinks = (TAudioSink[])null;
-                        var videoSinks = (TVideoSink[])null;
-                        var connection = (ManagedConnection)null;
-                        var connectedSource = new TaskCompletionSource<bool>();
-                        var connected = connectedSource.Task;
-                        var disconnected = (Task)null;
+                        Console.Error.WriteLine($"{GetType().Name} is waiting for connection '{Options.ConnectionId}'.");
 
-                        var connect = new Func<ConnectionInfo, Task>(async (remoteConnectionInfo) =>
-                        {
-                            var audioStream = CreateAudioStream(remoteConnectionInfo);
-                            var videoStream = CreateVideoStream(remoteConnectionInfo);
-                            var dataStream = CreateDataStream(remoteConnectionInfo);
-                            connection = Options.CreateConnection(channel, remoteConnectionInfo, audioStream, videoStream, dataStream);
+                        RemoteConnectionInfo = await GetRemoteConnectionInfo();
 
-                            Console.Error.WriteLine($"{GetType().Name} connection '{connection.Id}' created:{Environment.NewLine}{Descriptor.Format(connection.GetDescriptors())}");
+                        InitializeAudioStream();
+                        InitializeVideoStream();
+                        InitializeDataStream();
 
-                            audioSinks = audioStream?.RemoteTrack.Sinks.Select(x => x as TAudioSink).ToArray();
-                            videoSinks = videoStream?.RemoteTrack.Sinks.Select(x => x as TVideoSink).ToArray();
+                        Connection = Options.CreateConnection(Channel, RemoteConnectionInfo, AudioStream, VideoStream, DataStream);
 
-                            SinksReady(audioSinks, videoSinks);
+                        Console.Error.WriteLine($"{GetType().Name} connection created:{Environment.NewLine}{Descriptor.Format(Connection.GetDescriptors())}");
 
-                            disconnected = await connection.Connect();
+                        Disconnected = await Connection.Connect();
 
-                            connectedSource.TrySetResult(true);
-                        });
+                        await Task.WhenAll(
+                            StartAudioStream(),
+                            StartVideoStream(),
+                            StartDataStream());
 
-                        if (Options.ConnectionId == "mcu")
-                        {
-                            _ = Task.Run(async () =>
-                            {
-                                await connect(GetMcuConnectionInfo());
-                            });
-                        }
-                        else
-                        {
-                            var notifiedSource = new TaskCompletionSource<bool>();
-                            var notified = notifiedSource.Task;
-                            channel.OnRemoteUpstreamConnectionOpen += async (remoteConnectionInfo) =>
-                            {
-                                if (remoteConnectionInfo.Id == Options.ConnectionId)
-                                {
-                                    notifiedSource.TrySetResult(true);
-
-                                    var remoteClientInfo = channel.GetRemoteClientInfo(remoteConnectionInfo.ClientId);
-                                    if (remoteClientInfo != null)
-                                    {
-                                        Console.Error.WriteLine($"Remote client '{remoteConnectionInfo.ClientId}' found:{Environment.NewLine}{Descriptor.Format(remoteClientInfo.GetDescriptors())}");
-                                    }
-
-                                    Console.Error.WriteLine($"Remote connection '{Options.ConnectionId}' found:{Environment.NewLine}{Descriptor.Format(remoteConnectionInfo.GetDescriptors())}");
-
-                                    await connect(remoteConnectionInfo);
-                                }
-                            };
-                            channel.OnRemoteUpstreamConnectionClose += (remoteConnectionInfo) =>
-                            {
-                                if (remoteConnectionInfo.RemoteConnectionId == Options.ConnectionId)
-                                {
-                                    Console.Error.WriteLine("Remote disconnected.");
-                                }
-                            };
-
-                            Console.Error.WriteLine($"Waiting for remote connection...");
-
-                            if (await Task.WhenAny(timeout, notified) == timeout)
-                            {
-                                Console.Error.WriteLine($"Remote connection '{Options.ConnectionId}' does not exist.");
-                                return 1;
-                            }
-                        }
-
-                        Console.Error.WriteLine($"Connecting...");
-
-                        if (await Task.WhenAny(timeout, connected) == timeout)
-                        {
-                            Console.Error.WriteLine($"Timeout connecting to '{Options.ConnectionId}'.");
-                            return 1;
-                        }
+                        await Ready();
 
                         // watch for exit signal
                         var exitSignalledSource = new TaskCompletionSource<bool>();
@@ -127,26 +111,35 @@ namespace FM.LiveSwitch.Connect
 
                             e.Cancel = true;
 
-                            SinksUnready(audioSinks, videoSinks);
+                            await Unready();
 
-                            // close connections gracefully
-                            await connection.Disconnect();
+                            await Task.WhenAll(
+                                StopAudioStream(),
+                                StopVideoStream(),
+                                StopDataStream());
+
+                            // close connection gracefully
+                            await Connection.Disconnect();
+
+                            DestroyAudioStream();
+                            DestroyVideoStream();
+                            DestroyDataStream();
 
                             exitSignalledSource.TrySetResult(true); // exit handling
                         };
 
                         // wait for exit signal
-                        Console.Error.WriteLine("Waiting for exit signal or remote disconnect...");
-                        await Task.WhenAny(exitSignalled, disconnected);
+                        Console.Error.WriteLine("Waiting for exit signal or disconnect...");
+                        await Task.WhenAny(exitSignalled, Disconnected);
                     }
                     finally
                     {
-                        await client.Leave(channel.Id);
+                        await Client.Leave(Channel.Id);
                     }
                 }
                 finally
                 {
-                    await client.Unregister();
+                    await Client.Unregister();
                 }
                 return 0;
             }
@@ -155,6 +148,35 @@ namespace FM.LiveSwitch.Connect
                 Console.Error.WriteLine(ex);
                 return -1;
             }
+        }
+
+        private Task<ConnectionInfo> GetRemoteConnectionInfo()
+        {
+            var taskCompletionSource = new TaskCompletionSource<ConnectionInfo>();
+
+            if (Options.ConnectionId == "mcu")
+            {
+                taskCompletionSource.TrySetResult(GetMcuConnectionInfo());
+            }
+            else
+            {
+                Channel.OnRemoteUpstreamConnectionOpen += (remoteConnectionInfo) =>
+                {
+                    if (remoteConnectionInfo.Id == Options.ConnectionId)
+                    {
+                        taskCompletionSource.TrySetResult(remoteConnectionInfo);
+                    }
+                };
+                foreach (var remoteConnectionInfo in Channel.RemoteUpstreamConnectionInfos)
+                {
+                    if (remoteConnectionInfo.Id == Options.ConnectionId)
+                    {
+                        taskCompletionSource.TrySetResult(remoteConnectionInfo);
+                    }
+                }
+            }
+
+            return taskCompletionSource.Task;
         }
 
         private ConnectionInfo GetMcuConnectionInfo()
@@ -171,35 +193,415 @@ namespace FM.LiveSwitch.Connect
             };
         }
 
-        protected abstract AudioStream CreateAudioStream(ConnectionInfo remoteConnectionInfo);
+        #region Audio
 
-        protected abstract VideoStream CreateVideoStream(ConnectionInfo remoteConnectionInfo);
-
-        protected DataStream CreateDataStream(ConnectionInfo remoteConnectionInfo)
+        protected virtual int GetAudioFrameDuration()
         {
-            if (Options.DataChannelLabel == null || !remoteConnectionInfo.HasData)
-            {
-                return null;
-            }
-
-            return new DataStream(new DataChannel(Options.DataChannelLabel)
-            {
-                OnReceive = (args) =>
-                {
-                    if (args.DataString != null)
-                    {
-                        Console.WriteLine(args.DataString);
-                    }
-                    else
-                    {
-                        Console.Error.WriteLine($"Cannot write binary message from data channel: {args.DataBytes.ToHexString()}");
-                    }
-                }
-            });
+            return -1;
         }
 
-        protected virtual void SinksReady(TAudioSink[] audioSinks, TVideoSink[] videoSinks) { }
+        private bool InitializeAudioStream()
+        {
+            if (Options.NoAudio || !RemoteConnectionInfo.HasAudio)
+            {
+                return false;
+            }
 
-        protected virtual void SinksUnready(TAudioSink[] audioSinks, TVideoSink[] videoSinks) { }
+            AudioPipes = Options.GetAudioEncodings().Select(audioEncoding =>
+            {
+                return new IdentityAudioPipe(audioEncoding.CreateFormat(true));
+            }).ToArray();
+
+            AudioStream = new AudioStream(null, AudioPipes);
+            
+            if (Options.AudioBitrate.HasValue)
+            {
+                AudioStream.LocalBandwidth = Options.AudioBitrate.Value;
+            }
+            
+            DoInitializeAudioStream();
+            return true;
+        }
+
+        private Task StartAudioStream()
+        {
+            if (AudioStream != null)
+            {
+                var outputFormat = AudioStream.OutputFormat;
+                if (outputFormat == null)
+                {
+                    throw new Exception("Could not negotiate an audio codec with the server.");
+                }
+                AudioFormat = outputFormat.Clone();
+
+                AudioSink = CreateAudioSink();
+
+                var currentInput = (IAudioInput)AudioSink;
+
+                if (Options.AudioTranscode)
+                {
+                    if (currentInput.InputFormat.IsPacketized)
+                    {
+                        AudioPacketizer = currentInput.InputFormat.ToEncoding().CreatePacketizer();
+
+                        currentInput.AddInput(AudioPacketizer);
+                        currentInput = AudioPacketizer;
+                    }
+
+                    if (currentInput.InputFormat.IsCompressed)
+                    {
+                        AudioEncoder = currentInput.InputFormat.ToEncoding().CreateEncoder();
+
+                        currentInput.AddInput(AudioEncoder);
+                        currentInput = AudioEncoder;
+                    }
+
+                    ResetAudioPipe = new ResetAudioPipe(currentInput.InputFormat);
+                    currentInput.AddInput(ResetAudioPipe);
+                    currentInput = ResetAudioPipe;
+                }
+
+                if (!currentInput.InputFormat.IsCompressed)
+                {
+                    AudioDecoder = AudioFormat.ToEncoding().CreateDecoder();
+
+                    AudioConverter = new SoundConverter(AudioDecoder.OutputConfig, currentInput.Config);
+
+                    var frameDuration = GetAudioFrameDuration();
+                    if (frameDuration != -1)
+                    {
+                        AudioReframer = new SoundReframer(currentInput.Config, frameDuration);
+                        currentInput.AddInput(AudioReframer);
+                        currentInput = AudioReframer;
+                    }
+
+                    currentInput.AddInput(AudioConverter);
+                    currentInput = AudioConverter;
+
+                    currentInput.AddInput(AudioDecoder);
+                    currentInput = AudioDecoder;
+                }
+
+                if (!currentInput.InputFormat.IsPacketized)
+                {
+                    AudioDepacketizer = AudioFormat.ToEncoding().CreateDepacketizer();
+
+                    currentInput.AddInput(AudioDepacketizer);
+                    currentInput = AudioDepacketizer;
+                }
+
+                var streamOutput = null as AudioPipe;
+                foreach (var output in AudioStream.Outputs)
+                {
+                    if (output.InputFormat.IsEquivalent(AudioFormat, true))
+                    {
+                        streamOutput = output as AudioPipe;
+                    }
+                }
+
+                currentInput.AddInput(streamOutput);
+
+                if (AudioEncoder != null && !AudioEncoder.OutputFormat.IsFixedBitrate && Options.AudioBitrate.HasValue)
+                {
+                    AudioEncoder.TargetBitrate = Options.AudioBitrate.Value;
+                }
+            }
+            return Task.CompletedTask;
+        }
+
+        private Task StopAudioStream()
+        {
+            if (AudioDepacketizer != null)
+            {
+                AudioDepacketizer.Destroy();
+                AudioDepacketizer = null;
+            }
+            if (AudioDecoder != null)
+            {
+                AudioDecoder.Destroy();
+                AudioDecoder = null;
+            }
+            if (AudioConverter != null)
+            {
+                AudioConverter.Destroy();
+                AudioConverter = null;
+            }
+            if (ResetAudioPipe != null)
+            {
+                ResetAudioPipe.Destroy();
+                ResetAudioPipe = null;
+            }
+            if (AudioEncoder != null)
+            {
+                AudioEncoder.Destroy();
+                AudioEncoder = null;
+            }
+            if (AudioPacketizer != null)
+            {
+                AudioPacketizer.Destroy();
+                AudioPacketizer = null;
+            }
+            if (AudioSink != null)
+            {
+                AudioSink.Destroy();
+                AudioSink = null;
+            }
+            return Task.CompletedTask;
+        }
+
+        private void DestroyAudioStream()
+        {
+            if (AudioStream != null)
+            {
+                DoDestroyAudioStream();
+                AudioStream = null;
+            }
+            if (AudioPipes != null)
+            {
+                foreach (var pipe in AudioPipes)
+                {
+                    pipe.Destroy();
+                }
+                AudioPipes = null;
+            }
+        }
+
+        protected virtual void DoInitializeAudioStream() { }
+        protected virtual void DoDestroyAudioStream() { }
+
+        #endregion
+
+        #region Video
+
+        private bool InitializeVideoStream()
+        {
+            if (Options.NoVideo || !RemoteConnectionInfo.HasVideo)
+            {
+                return false;
+            }
+
+            VideoPipes = Options.GetVideoEncodings().Select(videoEncoding =>
+            {
+                return new IdentityVideoPipe(videoEncoding.CreateFormat(true));
+            }).ToArray();
+
+            VideoStream = new VideoStream(null, VideoPipes);
+
+            if (Options.VideoBitrate.HasValue)
+            {
+                VideoStream.LocalBandwidth = Options.VideoBitrate.Value;
+            }
+
+            DoInitializeVideoStream();
+            return true;
+        }
+
+        private Task StartVideoStream()
+        {
+            if (VideoStream != null)
+            {
+                var outputFormat = VideoStream.OutputFormat;
+                if (outputFormat == null)
+                {
+                    throw new Exception("Could not negotiate an video codec with the server.");
+                }
+                VideoFormat = outputFormat.Clone();
+
+                VideoSink = CreateVideoSink();
+
+                var currentInput = (IVideoInput)VideoSink;
+
+                if (Options.VideoTranscode)
+                {
+                    if (currentInput.InputFormat.IsPacketized)
+                    {
+                        VideoPacketizer = currentInput.InputFormat.ToEncoding().CreatePacketizer();
+
+                        currentInput.AddInput(VideoPacketizer);
+                        currentInput = VideoPacketizer;
+                    }
+
+                    if (currentInput.InputFormat.IsCompressed)
+                    {
+                        VideoEncoder = currentInput.InputFormat.ToEncoding().CreateEncoder();
+
+                        currentInput.AddInput(VideoEncoder);
+                        currentInput = VideoEncoder;
+                    }
+
+                    ResetVideoPipe = new ResetVideoPipe(currentInput.InputFormat);
+                    currentInput.AddInput(ResetVideoPipe);
+                    currentInput = ResetVideoPipe;
+                }
+
+                if (!currentInput.InputFormat.IsCompressed)
+                {
+                    VideoDecoder = VideoFormat.ToEncoding().CreateDecoder();
+
+                    VideoConverter = new ImageConverter(VideoDecoder.OutputFormat, currentInput.InputFormat);
+
+                    currentInput.AddInput(VideoConverter);
+                    currentInput = VideoConverter;
+
+                    currentInput.AddInput(VideoDecoder);
+                    currentInput = VideoDecoder;
+                }
+
+                if (!currentInput.InputFormat.IsPacketized)
+                {
+                    VideoDepacketizer = VideoFormat.ToEncoding().CreateDepacketizer();
+
+                    currentInput.AddInput(VideoDepacketizer);
+                    currentInput = VideoDepacketizer;
+                }
+
+                var streamOutput = null as VideoPipe;
+                foreach (var output in VideoStream.Outputs)
+                {
+                    if (output.InputFormat.IsEquivalent(VideoFormat, true))
+                    {
+                        streamOutput = output as VideoPipe;
+                    }
+                }
+
+                currentInput.AddInput(streamOutput);
+
+                if (VideoEncoder != null && !VideoEncoder.OutputFormat.IsFixedBitrate && Options.VideoBitrate.HasValue)
+                {
+                    VideoEncoder.TargetBitrate = Options.VideoBitrate.Value;
+                }
+            }
+            return Task.CompletedTask;
+        }
+
+        private Task StopVideoStream()
+        {
+            if (VideoDepacketizer != null)
+            {
+                VideoDepacketizer.Destroy();
+                VideoDepacketizer = null;
+            }
+            if (VideoDecoder != null)
+            {
+                VideoDecoder.Destroy();
+                VideoDecoder = null;
+            }
+            if (VideoConverter != null)
+            {
+                VideoConverter.Destroy();
+                VideoConverter = null;
+            }
+            if (ResetVideoPipe != null)
+            {
+                ResetVideoPipe.Destroy();
+                ResetVideoPipe = null;
+            }
+            if (VideoEncoder != null)
+            {
+                VideoEncoder.Destroy();
+                VideoEncoder = null;
+            }
+            if (VideoPacketizer != null)
+            {
+                VideoPacketizer.Destroy();
+                VideoPacketizer = null;
+            }
+            if (VideoSink != null)
+            {
+                VideoSink.Destroy();
+                VideoSink = null;
+            }
+            return Task.CompletedTask;
+        }
+
+        private void DestroyVideoStream()
+        {
+            if (VideoStream != null)
+            {
+                DoDestroyVideoStream();
+                VideoStream = null;
+            }
+            if (VideoPipes != null)
+            {
+                foreach (var pipe in VideoPipes)
+                {
+                    pipe.Destroy();
+                }
+                VideoPipes = null;
+            }
+        }
+
+        protected virtual void DoInitializeVideoStream() { }
+        protected virtual void DoDestroyVideoStream() { }
+
+        #endregion
+
+        #region Data
+
+        private bool InitializeDataStream()
+        {
+            if (Options.DataChannelLabel == null || !RemoteConnectionInfo.HasData)
+            {
+                return false;
+            }
+
+            DataChannel = new DataChannel(Options.DataChannelLabel);
+            DataStream = new DataStream(DataChannel);
+            DoInitializeDataStream();
+            return true;
+        }
+
+        private Task StartDataStream()
+        {
+            if (DataStream != null)
+            {
+                DataSink = CreateDataSink();
+                DataChannel.OnReceive = DataSink.ProcessReceive;
+            }
+            return Task.CompletedTask;
+        }
+
+        private Task StopDataStream()
+        {
+            if (DataStream != null)
+            {
+                DataSink = null;
+            }
+            return Task.CompletedTask;
+        }
+
+        private void DestroyDataStream()
+        {
+            if (DataStream != null)
+            {
+                DoDestroyDataStream();
+                DataStream = null;
+                DataChannel = null;
+            }
+        }
+
+        protected virtual void DoInitializeDataStream() { }
+        protected virtual void DoDestroyDataStream() { }
+
+        #endregion
+
+        protected abstract TAudioSink CreateAudioSink();
+
+        protected abstract TVideoSink CreateVideoSink();
+
+        protected virtual DataSink CreateDataSink()
+        {
+            return new DataSink();
+        }
+
+        protected virtual Task Ready()
+        {
+            return Task.CompletedTask;
+        }
+
+        protected virtual Task Unready()
+        {
+            return Task.CompletedTask;
+        }
     }
 }

--- a/src/FM.LiveSwitch.Connect/Receiver.cs
+++ b/src/FM.LiveSwitch.Connect/Receiver.cs
@@ -123,7 +123,15 @@ namespace FM.LiveSwitch.Connect
 
                             await Task.WhenAny(ExitSignal(), Disconnected);
 
-                            if (Client.UnregisterException == null)
+                            if (Connection.State == ConnectionState.Failed)
+                            {
+                                Console.Error.WriteLine($"{GetType().Name} connection failed. {Client.UnregisterException}");
+                            }
+                            else if (Client.UnregisterException != null)
+                            {
+                                Console.Error.WriteLine($"{GetType().Name} client failed. {Client.UnregisterException}");
+                            }
+                            else
                             {
                                 if (Disconnected.IsCompletedSuccessfully)
                                 {
@@ -134,10 +142,6 @@ namespace FM.LiveSwitch.Connect
                                     Console.Error.WriteLine($"{GetType().Name} received exit signal.");
                                 }
                                 exit = true;
-                            }
-                            else
-                            {
-                                Console.Error.WriteLine($"{GetType().Name} client was disconnected. {Client.UnregisterException}");
                             }
 
                             await Unready();
@@ -151,9 +155,12 @@ namespace FM.LiveSwitch.Connect
 
                             Console.Error.WriteLine($"{GetType().Name} streams stopped.");
 
-                            await Connection.Disconnect();
+                            if (Connection.State == ConnectionState.Connected)
+                            {
+                                await Connection.Disconnect();
 
-                            Console.Error.WriteLine($"{GetType().Name} connection disconnected.");
+                                Console.Error.WriteLine($"{GetType().Name} connection disconnected.");
+                            }
 
                             DestroyAudioStream();
                             DestroyVideoStream();

--- a/src/FM.LiveSwitch.Connect/Receiver.cs
+++ b/src/FM.LiveSwitch.Connect/Receiver.cs
@@ -71,75 +71,129 @@ namespace FM.LiveSwitch.Connect
 
             try
             {
-                Client = Options.CreateClient();
-
-                Console.Error.WriteLine($"{GetType().Name} client created:{Environment.NewLine}{Descriptor.Format(Client.GetDescriptors())}");
-
-                await Client.Register(Options);
-                try
+                var exit = false;
+                while (!exit)
                 {
-                    Channel = await Client.Join(Options);
+                    Client = Options.CreateClient();
+
+                    Console.Error.WriteLine($"{GetType().Name} client created:{Environment.NewLine}{Descriptor.Format(Client.GetDescriptors())}");
+
+                    await Client.Register(Options);
+
+                    Console.Error.WriteLine($"{GetType().Name} client registered: {Options.ApplicationId}");
+
                     try
                     {
-                        Console.Error.WriteLine($"{GetType().Name} is waiting for connection '{Options.ConnectionId}'.");
+                        Channel = await Client.Join(Options);
 
-                        RemoteConnectionInfo = await GetRemoteConnectionInfo();
+                        Console.Error.WriteLine($"{GetType().Name} client joined: {Channel.Id}");
 
-                        InitializeAudioStream();
-                        InitializeVideoStream();
-                        InitializeDataStream();
-
-                        Connection = Options.CreateConnection(Channel, RemoteConnectionInfo, AudioStream, VideoStream, DataStream);
-
-                        Console.Error.WriteLine($"{GetType().Name} connection created:{Environment.NewLine}{Descriptor.Format(Connection.GetDescriptors())}");
-
-                        Disconnected = await Connection.Connect();
-
-                        await Task.WhenAll(
-                            StartAudioStream(),
-                            StartVideoStream(),
-                            StartDataStream());
-
-                        await Ready();
-
-                        // watch for exit signal
-                        var exitSignalledSource = new TaskCompletionSource<bool>();
-                        var exitSignalled = exitSignalledSource.Task;
-                        Console.CancelKeyPress += async (sender, e) =>
+                        try
                         {
-                            Console.Error.WriteLine("Exit signalled.");
+                            Console.Error.WriteLine($"{GetType().Name} is waiting for remote connection '{Options.ConnectionId}'.");
 
-                            e.Cancel = true;
+                            RemoteConnectionInfo = await GetRemoteConnectionInfo();
+
+                            Console.Error.WriteLine($"{GetType().Name} has remote connection:{Environment.NewLine}{Descriptor.Format(RemoteConnectionInfo.GetDescriptors())}");
+
+                            InitializeAudioStream();
+                            InitializeVideoStream();
+                            InitializeDataStream();
+
+                            Console.Error.WriteLine($"{GetType().Name} streams initialized.");
+
+                            Connection = Options.CreateConnection(Channel, RemoteConnectionInfo, AudioStream, VideoStream, DataStream);
+
+                            Console.Error.WriteLine($"{GetType().Name} connection created:{Environment.NewLine}{Descriptor.Format(Connection.GetDescriptors())}");
+
+                            Disconnected = await Connection.Connect();
+
+                            Console.Error.WriteLine($"{GetType().Name} connection connected.");
+
+                            await Task.WhenAll(
+                                StartAudioStream(),
+                                StartVideoStream(),
+                                StartDataStream());
+
+                            Console.Error.WriteLine($"{GetType().Name} streams started.");
+
+                            await Ready();
+
+                            Console.Error.WriteLine($"{GetType().Name} is ready and waiting for exit signal or disconnect...");
+
+                            await Task.WhenAny(ExitSignal(), Disconnected);
+
+                            if (Client.UnregisterException == null)
+                            {
+                                if (Disconnected.IsCompletedSuccessfully)
+                                {
+                                    Console.Error.WriteLine($"{GetType().Name} connection was closed. {Client.UnregisterException}");
+                                }
+                                else
+                                {
+                                    Console.Error.WriteLine($"{GetType().Name} received exit signal.");
+                                }
+                                exit = true;
+                            }
+                            else
+                            {
+                                Console.Error.WriteLine($"{GetType().Name} client was disconnected. {Client.UnregisterException}");
+                            }
 
                             await Unready();
+
+                            Console.Error.WriteLine($"{GetType().Name} is not ready.");
 
                             await Task.WhenAll(
                                 StopAudioStream(),
                                 StopVideoStream(),
                                 StopDataStream());
 
-                            // close connection gracefully
+                            Console.Error.WriteLine($"{GetType().Name} streams stopped.");
+
                             await Connection.Disconnect();
+
+                            Console.Error.WriteLine($"{GetType().Name} connection disconnected.");
 
                             DestroyAudioStream();
                             DestroyVideoStream();
                             DestroyDataStream();
 
-                            exitSignalledSource.TrySetResult(true); // exit handling
-                        };
+                            Console.Error.WriteLine($"{GetType().Name} streams destroyed.");
+                        }
+                        finally
+                        {
+                            if (Client.State == ClientState.Registered)
+                            {
+                                try
+                                {
+                                    await Client.Leave(Channel.Id);
 
-                        // wait for exit signal
-                        Console.Error.WriteLine("Waiting for exit signal or disconnect...");
-                        await Task.WhenAny(exitSignalled, Disconnected);
+                                    Console.Error.WriteLine($"{GetType().Name} client left.");
+                                }
+                                catch (Exception ex)
+                                {
+                                    Console.Error.WriteLine($"Could not leave gracefully. {ex}");
+                                }
+                            }
+                        }
                     }
                     finally
                     {
-                        await Client.Leave(Channel.Id);
+                        if (Client.State == ClientState.Registered)
+                        {
+                            try
+                            {
+                                await Client.Unregister();
+
+                                Console.Error.WriteLine($"{GetType().Name} client unregistered.");
+                            }
+                            catch (Exception ex)
+                            {
+                                Console.Error.WriteLine($"Could not unregister gracefully. {ex}");
+                            }
+                        }
                     }
-                }
-                finally
-                {
-                    await Client.Unregister();
                 }
                 return 0;
             }
@@ -148,6 +202,19 @@ namespace FM.LiveSwitch.Connect
                 Console.Error.WriteLine(ex);
                 return -1;
             }
+        }
+
+        private Task ExitSignal()
+        {
+            var taskCompletionSource = new TaskCompletionSource<bool>();
+
+            Console.CancelKeyPress += (sender, e) =>
+            {
+                e.Cancel = true;
+                taskCompletionSource.TrySetResult(true);
+            };
+
+            return taskCompletionSource.Task;
         }
 
         private Task<ConnectionInfo> GetRemoteConnectionInfo()

--- a/src/FM.LiveSwitch.Connect/Recorder.cs
+++ b/src/FM.LiveSwitch.Connect/Recorder.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
 using System.IO;
 using System.Threading.Tasks;
 
@@ -40,16 +39,11 @@ namespace FM.LiveSwitch.Connect
                 .Replace("{mediaId}", remoteConnectionInfo.MediaId);
         }
 
-        protected override AudioStream CreateAudioStream(ConnectionInfo remoteConnectionInfo)
+        protected override Matroska.AudioSink CreateAudioSink()
         {
-            if (Options.NoAudio || !remoteConnectionInfo.HasAudio)
-            {
-                return null;
-            }
-
             var fileIndex = 0;
             var fileExtension = "mka";
-            var filePathWithoutExtension = ProcessFilePath(Path.Combine(Options.OutputPath, Options.OutputFileName), remoteConnectionInfo);
+            var filePathWithoutExtension = ProcessFilePath(Path.Combine(Options.OutputPath, Options.OutputFileName), RemoteConnectionInfo);
             var filePath = $"{filePathWithoutExtension}-{fileIndex}.{fileExtension}";
             while (File.Exists(filePath))
             {
@@ -58,32 +52,17 @@ namespace FM.LiveSwitch.Connect
 
             //TODO: should the JSON here follow the media server conventions?
             var jsonPath = filePath + ".json";
-            File.WriteAllText(jsonPath, remoteConnectionInfo.ToJson());
+            File.WriteAllText(jsonPath, RemoteConnectionInfo.ToJson());
             Console.WriteLine(jsonPath);
 
-            var track = CreateAudioTrack(filePath);
-            var stream = new AudioStream(null, track);
-            stream.OnStateChange += () =>
-            {
-                if (stream.State == StreamState.Closed ||
-                    stream.State == StreamState.Failed)
-                {
-                    track.Destroy();
-                }
-            };
-            return stream;
+            return new Matroska.AudioSink(filePath);
         }
 
-        protected override VideoStream CreateVideoStream(ConnectionInfo remoteConnectionInfo)
+        protected override Matroska.VideoSink CreateVideoSink()
         {
-            if (Options.NoVideo || !remoteConnectionInfo.HasVideo)
-            {
-                return null;
-            }
-
             var fileIndex = 0;
             var fileExtension = "mkv";
-            var filePathWithoutExtension = ProcessFilePath(Path.Combine(Options.OutputPath, Options.OutputFileName), remoteConnectionInfo);
+            var filePathWithoutExtension = ProcessFilePath(Path.Combine(Options.OutputPath, Options.OutputFileName), RemoteConnectionInfo);
             var filePath = $"{filePathWithoutExtension}-{fileIndex}.{fileExtension}";
             while (File.Exists(filePath))
             {
@@ -92,74 +71,10 @@ namespace FM.LiveSwitch.Connect
 
             //TODO: should the JSON here follow the media server conventions?
             var jsonPath = filePath + ".json";
-            File.WriteAllText(jsonPath, remoteConnectionInfo.ToJson());
+            File.WriteAllText(jsonPath, RemoteConnectionInfo.ToJson());
             Console.WriteLine(jsonPath);
 
-            var track = CreateVideoTrack(filePath);
-            var stream = new VideoStream(null, track);
-            stream.OnStateChange += () =>
-            {
-                if (stream.State == StreamState.Closed ||
-                    stream.State == StreamState.Failed)
-                {
-                    track.Destroy();
-                }
-            };
-            return stream;
-        }
-
-        private AudioTrack CreateAudioTrack(string filePath)
-        {
-            var tracks = new List<AudioTrack>();
-            foreach (var inputEncoding in (AudioEncoding[])Enum.GetValues(typeof(AudioEncoding)))
-            {
-                var outputEncoding = Options.AudioCodec == AudioCodec.Any ? inputEncoding : Options.AudioCodec.ToEncoding();
-                tracks.Add(CreateAudioTrack(inputEncoding, outputEncoding, filePath));
-            }
-            return new AudioTrack(tracks.ToArray());
-        }
-
-        private VideoTrack CreateVideoTrack(string filePath)
-        {
-            var tracks = new List<VideoTrack>();
-            foreach (var inputEncoding in (VideoEncoding[])Enum.GetValues(typeof(VideoEncoding)))
-            {
-                var outputEncoding = Options.VideoCodec == VideoCodec.Any ? inputEncoding : Options.VideoCodec.ToEncoding();
-                if (Options.DisableOpenH264 && (inputEncoding == VideoEncoding.H264 || outputEncoding == VideoEncoding.H264))
-                {
-                    continue;
-                }
-                tracks.Add(CreateVideoTrack(inputEncoding, outputEncoding, filePath));
-            }
-            return new VideoTrack(tracks.ToArray());
-        }
-
-        private AudioTrack CreateAudioTrack(AudioEncoding inputCodec, AudioEncoding outputCodec, string filePath)
-        {
-            var depacketizer = inputCodec.CreateDepacketizer();
-            var sink = new Matroska.AudioSink(filePath);
-            if (inputCodec == outputCodec)
-            {
-                return new AudioTrack(depacketizer).Next(sink);
-            }
-
-            var decoder = inputCodec.CreateDecoder();
-            var encoder = outputCodec.CreateEncoder();
-            return new AudioTrack(depacketizer).Next(decoder).Next(new SoundConverter(encoder.InputConfig)).Next(encoder).Next(sink);
-        }
-
-        private VideoTrack CreateVideoTrack(VideoEncoding inputCodec, VideoEncoding outputCodec, string filePath)
-        {
-            var depacketizer = inputCodec.CreateDepacketizer();
-            var sink = new Matroska.VideoSink(filePath);
-            if (inputCodec == outputCodec)
-            {
-                return new VideoTrack(depacketizer).Next(sink);
-            }
-
-            var decoder = inputCodec.CreateDecoder();
-            var encoder = outputCodec.CreateEncoder();
-            return new VideoTrack(depacketizer).Next(decoder).Next(new Yuv.ImageConverter(encoder.InputFormat)).Next(encoder).Next(sink);
+            return new Matroska.VideoSink(filePath);
         }
     }
 }

--- a/src/FM.LiveSwitch.Connect/RolloverContext.cs
+++ b/src/FM.LiveSwitch.Connect/RolloverContext.cs
@@ -1,0 +1,89 @@
+﻿using System;
+
+namespace FM.LiveSwitch.Connect
+{
+    class RolloverContext
+    {
+        public int Bits
+        {
+            get { return _Bits; }
+            set
+            {
+                _Bits = value;
+                _RolloverSize = (int)MathAssistant.Pow(2, _Bits);
+                _RolloverSize_2 = _RolloverSize / 2;
+            }
+        }
+        private int _Bits;
+
+        public long RolloverCounter { get; private set; }
+
+        public long HighestValue { get; private set; }
+
+        private long _RolloverSize;
+        private long _RolloverSize_2;
+
+        public RolloverContext(int bits)
+        {
+            if (bits < 2)
+            {
+                throw new Exception("Minimum bits is 2.");
+            }
+
+            Bits = bits;
+            RolloverCounter = 0;
+            HighestValue = -1;
+        }
+
+        public long GetIndex(long value)
+        {
+            long roc = 0;
+            return GetIndex(value, out roc);
+        }
+
+        public long GetIndex(long value, out long rolloverCounter) // i
+        {
+            if (HighestValue == -1)
+            {
+                HighestValue = value;
+                rolloverCounter = RolloverCounter;
+                return value;
+            }
+
+            long v;
+            if (HighestValue < _RolloverSize_2)
+            {
+                // use > instead of >= to favour forward movement
+                if (value - HighestValue > _RolloverSize_2)
+                {
+                    v = (RolloverCounter - 1) % 4294967296;
+                }
+                else
+                {
+                    v = RolloverCounter;
+
+                    HighestValue = MathAssistant.Max(HighestValue, value);
+                }
+            }
+            else
+            {
+                // use >= instead of > to favour forward movement
+                if (HighestValue - _RolloverSize_2 >= value)
+                {
+                    v = (RolloverCounter + 1) % 4294967296;
+
+                    HighestValue = value;
+                    RolloverCounter = v;
+                }
+                else
+                {
+                    v = RolloverCounter;
+
+                    HighestValue = MathAssistant.Max(HighestValue, value);
+                }
+            }
+            rolloverCounter = v;
+            return _RolloverSize * v + value;
+        }
+    }
+}

--- a/src/FM.LiveSwitch.Connect/RtpAudioSink.cs
+++ b/src/FM.LiveSwitch.Connect/RtpAudioSink.cs
@@ -35,8 +35,14 @@
         protected override void DoProcessFrame(AudioFrame frame, AudioBuffer inputBuffer)
         {
             var rtpHeaders = inputBuffer.RtpHeaders;
-            foreach (var rtpHeader in rtpHeaders)
+            var rtpPayloads = inputBuffer.DataBuffers;
+            for (var i = 0; i < rtpHeaders.Length; i++)
             {
+                var rtpHeader = rtpHeaders[i];
+                if (rtpHeader == null)
+                {
+                    rtpHeader = new RtpPacketHeader();
+                }
                 if (rtpHeader.SequenceNumber == -1)
                 {
                     rtpHeader.SequenceNumber = (int)(_SequenceNumber++ % (ushort.MaxValue + 1));
@@ -45,12 +51,7 @@
                 {
                     rtpHeader.Timestamp = frame.Timestamp % ((long)uint.MaxValue + 1);
                 }
-            }
-
-            var rtpPayloads = inputBuffer.DataBuffers;
-            for (var i = 0; i < rtpHeaders.Length; i++)
-            {
-                _Writer.Write(new RtpPacket(rtpPayloads[i], rtpHeaders[i].SequenceNumber, rtpHeaders[i].Timestamp, rtpHeaders[i].Marker)
+                _Writer.Write(new RtpPacket(rtpPayloads[i], rtpHeader.SequenceNumber, rtpHeader.Timestamp, rtpHeader.Marker)
                 {
                     PayloadType = PayloadType,
                     SynchronizationSource = SynchronizationSource

--- a/src/FM.LiveSwitch.Connect/RtpAudioSink.cs
+++ b/src/FM.LiveSwitch.Connect/RtpAudioSink.cs
@@ -24,6 +24,7 @@
         public long SynchronizationSource { get; set; }
 
         private RtpWriter _Writer = null;
+        private long _SequenceNumber;
 
         public RtpAudioSink(AudioFormat format)
             : base(format)
@@ -34,6 +35,18 @@
         protected override void DoProcessFrame(AudioFrame frame, AudioBuffer inputBuffer)
         {
             var rtpHeaders = inputBuffer.RtpHeaders;
+            foreach (var rtpHeader in rtpHeaders)
+            {
+                if (rtpHeader.SequenceNumber == -1)
+                {
+                    rtpHeader.SequenceNumber = (int)(_SequenceNumber++ % (ushort.MaxValue + 1));
+                }
+                if (rtpHeader.Timestamp == -1)
+                {
+                    rtpHeader.Timestamp = frame.Timestamp % ((long)uint.MaxValue + 1);
+                }
+            }
+
             var rtpPayloads = inputBuffer.DataBuffers;
             for (var i = 0; i < rtpHeaders.Length; i++)
             {

--- a/src/FM.LiveSwitch.Connect/RtpAudioSink.cs
+++ b/src/FM.LiveSwitch.Connect/RtpAudioSink.cs
@@ -1,0 +1,53 @@
+﻿namespace FM.LiveSwitch.Connect
+{
+    class RtpAudioSink : AudioSink
+    {
+        public override string Label
+        {
+            get { return "RTP Audio Sink"; }
+        }
+
+        public string IPAddress
+        {
+            get { return _Writer.IPAddress; }
+            set { _Writer.IPAddress = value; }
+        }
+
+        public int Port
+        {
+            get { return _Writer.Port; }
+            set { _Writer.Port = value; }
+        }
+
+        public int PayloadType { get; set; }
+
+        public long SynchronizationSource { get; set; }
+
+        private RtpWriter _Writer = null;
+
+        public RtpAudioSink(AudioFormat format)
+            : base(format)
+        {
+            _Writer = new RtpWriter(format.ClockRate);
+        }
+
+        protected override void DoProcessFrame(AudioFrame frame, AudioBuffer inputBuffer)
+        {
+            var rtpHeaders = inputBuffer.RtpHeaders;
+            var rtpPayloads = inputBuffer.DataBuffers;
+            for (var i = 0; i < rtpHeaders.Length; i++)
+            {
+                _Writer.Write(new RtpPacket(rtpPayloads[i], rtpHeaders[i].SequenceNumber, rtpHeaders[i].Timestamp, rtpHeaders[i].Marker)
+                {
+                    PayloadType = PayloadType,
+                    SynchronizationSource = SynchronizationSource
+                });
+            }
+        }
+
+        protected override void DoDestroy()
+        {
+            _Writer.Destroy();
+        }
+    }
+}

--- a/src/FM.LiveSwitch.Connect/RtpAudioSource.cs
+++ b/src/FM.LiveSwitch.Connect/RtpAudioSource.cs
@@ -9,7 +9,9 @@
 
         public int Port { get { return _Reader.Port; } }
 
-        private RtpReader _Reader = null;
+        private RtpReader _Reader;
+        private RolloverContext _SequenceNumberRolloverContext;
+        private RolloverContext _TimestampRolloverContext;
 
         public RtpAudioSource(AudioFormat format)
             : base(format)
@@ -29,6 +31,9 @@
 
         private void Initialize()
         {
+            _SequenceNumberRolloverContext = new RolloverContext(16);
+            _TimestampRolloverContext = new RolloverContext(32);
+
             _Reader.OnPacket += (packet) =>
             {
                 packet.Payload.LittleEndian = OutputFormat.LittleEndian;
@@ -44,8 +49,8 @@
                 Marker = packet.Marker
             }))
             {
-                SequenceNumber = packet.SequenceNumber,
-                Timestamp = packet.Timestamp
+                SequenceNumber = _SequenceNumberRolloverContext.GetIndex(packet.SequenceNumber),
+                Timestamp = _TimestampRolloverContext.GetIndex(packet.Timestamp)
             });
         }
 

--- a/src/FM.LiveSwitch.Connect/RtpPacket.cs
+++ b/src/FM.LiveSwitch.Connect/RtpPacket.cs
@@ -6,6 +6,8 @@
         public long SequenceNumber { get; set; }
         public long Timestamp { get; set; }
         public bool Marker { get; set; }
+        public int PayloadType { get; set; }
+        public long SynchronizationSource { get; set; }
 
         public RtpPacket(DataBuffer payload, long sequenceNumber, long timestamp, bool marker)
         {

--- a/src/FM.LiveSwitch.Connect/RtpPacket.cs
+++ b/src/FM.LiveSwitch.Connect/RtpPacket.cs
@@ -3,13 +3,13 @@
     class RtpPacket
     {
         public DataBuffer Payload { get; set; }
-        public long SequenceNumber { get; set; }
+        public int SequenceNumber { get; set; }
         public long Timestamp { get; set; }
         public bool Marker { get; set; }
         public int PayloadType { get; set; }
         public long SynchronizationSource { get; set; }
 
-        public RtpPacket(DataBuffer payload, long sequenceNumber, long timestamp, bool marker)
+        public RtpPacket(DataBuffer payload, int sequenceNumber, long timestamp, bool marker)
         {
             Payload = payload;
             SequenceNumber = sequenceNumber;

--- a/src/FM.LiveSwitch.Connect/RtpReader.cs
+++ b/src/FM.LiveSwitch.Connect/RtpReader.cs
@@ -162,7 +162,7 @@ namespace FM.LiveSwitch.Connect
 
                 try
                 {
-                    OnPacket?.Invoke(new RtpPacket(buffer.Subset(header.CalculateHeaderLength()), sequenceNumber, timestamp, marker)
+                    OnPacket?.Invoke(new RtpPacket(buffer.Subset(header.CalculateHeaderLength()), header.SequenceNumber, header.Timestamp, header.Marker)
                     {
                         PayloadType = header.PayloadType,
                         SynchronizationSource = header.SynchronizationSource

--- a/src/FM.LiveSwitch.Connect/RtpVideoSink.cs
+++ b/src/FM.LiveSwitch.Connect/RtpVideoSink.cs
@@ -1,0 +1,73 @@
+﻿using System;
+
+namespace FM.LiveSwitch.Connect
+{
+    class RtpVideoSink : VideoSink
+    {
+        public override string Label
+        {
+            get { return "RTP Video Sink"; }
+        }
+
+        public string IPAddress
+        {
+            get { return _Writer.IPAddress; }
+            set { _Writer.IPAddress = value; }
+        }
+
+        public int Port
+        {
+            get { return _Writer.Port; }
+            set { _Writer.Port = value; }
+        }
+
+        public int PayloadType { get; set; }
+
+        public long SynchronizationSource { get; set; }
+
+        public int KeyFrameInterval { get; set; }
+
+        private RtpWriter _Writer = null;
+
+        public RtpVideoSink(VideoFormat format)
+            : base(format)
+        {
+            _Writer = new RtpWriter(format.ClockRate);
+        }
+
+        private int KeyFrameIntervalCounter;
+        private long LastTimestamp;
+
+        protected override void DoProcessFrame(VideoFrame frame, VideoBuffer inputBuffer)
+        {
+            if (frame.Timestamp != LastTimestamp)
+            {
+                KeyFrameIntervalCounter++;
+                LastTimestamp = frame.Timestamp;
+            }
+
+            if (KeyFrameIntervalCounter == KeyFrameInterval)
+            {
+                Console.Error.WriteLine("Raising keyframe request.");
+                RaiseControlFrame(new FirControlFrame(new FirEntry(GetCcmSequenceNumber())));
+                KeyFrameIntervalCounter = 0;
+            }
+
+            var rtpHeaders = inputBuffer.RtpHeaders;
+            var rtpPayloads = inputBuffer.DataBuffers;
+            for (var i = 0; i < rtpHeaders.Length; i++)
+            {
+                _Writer.Write(new RtpPacket(rtpPayloads[i], frame.SequenceNumber + i, frame.Timestamp, rtpHeaders[i].Marker)
+                {
+                    PayloadType = PayloadType,
+                    SynchronizationSource = SynchronizationSource
+                });
+            }
+        }
+
+        protected override void DoDestroy()
+        {
+            _Writer.Destroy();
+        }
+    }
+}

--- a/src/FM.LiveSwitch.Connect/RtpVideoSink.cs
+++ b/src/FM.LiveSwitch.Connect/RtpVideoSink.cs
@@ -54,8 +54,14 @@ namespace FM.LiveSwitch.Connect
             }
 
             var rtpHeaders = inputBuffer.RtpHeaders;
-            foreach (var rtpHeader in rtpHeaders)
+            var rtpPayloads = inputBuffer.DataBuffers;
+            for (var i = 0; i < rtpHeaders.Length; i++)
             {
+                var rtpHeader = rtpHeaders[i];
+                if (rtpHeader == null)
+                {
+                    rtpHeader = new RtpPacketHeader();
+                }
                 if (rtpHeader.SequenceNumber == -1)
                 {
                     rtpHeader.SequenceNumber = (int)(_SequenceNumber++ % (ushort.MaxValue + 1));
@@ -64,12 +70,7 @@ namespace FM.LiveSwitch.Connect
                 {
                     rtpHeader.Timestamp = frame.Timestamp % ((long)uint.MaxValue + 1);
                 }
-            }
-
-            var rtpPayloads = inputBuffer.DataBuffers;
-            for (var i = 0; i < rtpHeaders.Length; i++)
-            {
-                _Writer.Write(new RtpPacket(rtpPayloads[i], rtpHeaders[i].SequenceNumber, rtpHeaders[i].Timestamp, rtpHeaders[i].Marker)
+                _Writer.Write(new RtpPacket(rtpPayloads[i], rtpHeader.SequenceNumber, rtpHeader.Timestamp, rtpHeader.Marker)
                 {
                     PayloadType = PayloadType,
                     SynchronizationSource = SynchronizationSource

--- a/src/FM.LiveSwitch.Connect/RtpVideoSource.cs
+++ b/src/FM.LiveSwitch.Connect/RtpVideoSource.cs
@@ -15,8 +15,10 @@ namespace FM.LiveSwitch.Connect
 
         public DataBuffer[] ParameterSets { get; set; }
 
-        private RtpReader _Reader = null;
+        private RtpReader _Reader;
         private List<RtpPacket> _Queue;
+        private RolloverContext _SequenceNumberRolloverContext;
+        private RolloverContext _TimestampRolloverContext;
 
         public RtpVideoSource(VideoFormat format)
             : base(format)
@@ -37,6 +39,8 @@ namespace FM.LiveSwitch.Connect
         private void Initialize()
         {
             _Queue = new List<RtpPacket>();
+            _SequenceNumberRolloverContext = new RolloverContext(16);
+            _TimestampRolloverContext = new RolloverContext(32);
 
             _Reader.OnPacket += (packet) =>
             {
@@ -72,8 +76,8 @@ namespace FM.LiveSwitch.Connect
                 Marker = packet.Marker
             }))
             {
-                SequenceNumber = packet.SequenceNumber,
-                Timestamp = packet.Timestamp
+                SequenceNumber = _SequenceNumberRolloverContext.GetIndex(packet.SequenceNumber),
+                Timestamp = _TimestampRolloverContext.GetIndex(packet.Timestamp)
             });
         }
 

--- a/src/FM.LiveSwitch.Connect/RtpWriter.cs
+++ b/src/FM.LiveSwitch.Connect/RtpWriter.cs
@@ -1,0 +1,75 @@
+﻿using System;
+using System.Net;
+using System.Net.Sockets;
+
+namespace FM.LiveSwitch.Connect
+{
+    class RtpWriter
+    {
+        public int ClockRate { get; private set; }
+
+        public string IPAddress { get; set; }
+
+        public int Port { get; set; }
+
+        public int PayloadType { get; set; }
+
+        public long SynchronizationSource { get; set; }
+
+        private UdpClient _Client;
+        private DataBuffer _Buffer;
+        private IPEndPoint _IPEndPoint;
+
+        public RtpWriter(int clockRate)
+        {
+            ClockRate = clockRate;
+
+            _Client = CreateClient();
+            _Buffer = DataBuffer.Allocate(2048);
+        }
+
+        private UdpClient CreateClient()
+        {
+            return new UdpClient(AddressFamily.InterNetwork);
+        }
+
+        public void Destroy()
+        {
+            if (_Client != null)
+            {
+                _Client.Dispose();
+                _Client = null;
+            }
+        }
+
+        public bool Write(RtpPacket packet)
+        {
+            if (_IPEndPoint == null)
+            {
+                if (IPAddress == null || Port == 0)
+                {
+                    Console.Error.WriteLine("---- NEED TO ADD A QUEUE TO AVOID THIS");
+                    return false;
+                }
+                _IPEndPoint = new IPEndPoint(System.Net.IPAddress.Parse(IPAddress), Port);
+            }
+
+            var header = new RtpPacketHeader
+            {
+                Marker = packet.Marker,
+                Timestamp = packet.Timestamp % ((long)uint.MaxValue + 1),
+                SequenceNumber = (int)(packet.SequenceNumber % (ushort.MaxValue + 1)),
+                PayloadType = packet.PayloadType,
+                SynchronizationSource = packet.SynchronizationSource
+            };
+            var headerLength = header.CalculateHeaderLength();
+
+            header.WriteTo(_Buffer, 0);
+            _Buffer.Write(packet.Payload, headerLength);
+
+            _Client.Send(_Buffer.Data, headerLength + packet.Payload.Length, _IPEndPoint);
+
+            return true;
+        }
+    }
+}

--- a/src/FM.LiveSwitch.Connect/RtpWriter.cs
+++ b/src/FM.LiveSwitch.Connect/RtpWriter.cs
@@ -48,7 +48,7 @@ namespace FM.LiveSwitch.Connect
             {
                 if (IPAddress == null || Port == 0)
                 {
-                    Console.Error.WriteLine("---- NEED TO ADD A QUEUE TO AVOID THIS");
+                    Console.Error.WriteLine("IP address and port not set yet. Discarding packet.");
                     return false;
                 }
                 _IPEndPoint = new IPEndPoint(System.Net.IPAddress.Parse(IPAddress), Port);
@@ -57,8 +57,8 @@ namespace FM.LiveSwitch.Connect
             var header = new RtpPacketHeader
             {
                 Marker = packet.Marker,
-                Timestamp = packet.Timestamp % ((long)uint.MaxValue + 1),
-                SequenceNumber = (int)(packet.SequenceNumber % (ushort.MaxValue + 1)),
+                Timestamp = packet.Timestamp,
+                SequenceNumber = packet.SequenceNumber,
                 PayloadType = packet.PayloadType,
                 SynchronizationSource = packet.SynchronizationSource
             };


### PR DESCRIPTION
- Added `audio-mode` and `video-mode` options to `ffrender` to control where audio and video is decoded. Mirrors the options of the same name associated with `ffcapture`, which controls where audio and video is encoded. The default value is `lsdecode`, which delivers the media to ffmpeg in raw format. Setting the value to `noencode` will deliver the media to ffmpeg in compressed format, which reduces network consumption.
- Added `audio-encoding` and `video-encoding` options `ffrender` to control transcoding and the output encoding format. Mirrors the options of the same name associated with `ffcapture`, which controls transcoding and the input encoding format.
- Added `keyframe-interval` option to `ffrender` to control the rate at which keyframes are requested/generated. Only used if `video-mode` is `nodecode`. Mirrors the option of the same name associated with `ffcapture`, which controls the rate at which keyframes are generated.
- Added `audio-bitrate` and `video-bitrate` options to all receive verbs. These values can be used to request a specific bitrate from the Media Server, if multiple options are available or the sender supports dynamic bitrate.
- Added automatic restart of ffmpeg for `ffcapture` and `ffrender` if the process encounters an unexpected error or is otherwise terminated before an exit signal has been received.
- Added automatic reconnection to LiveSwitch if the signalling client or streaming connection fails for any reason.
- Updated the base `Receiver` to follow the same logical structure as the base `Sender` to eliminate code-reuse and limitations preventing efficient processing of inbound streams.
- Renamed the `ffencode-keyframe-interval` option for `ffcapture` to `keyframe-interval` for semantic accuracy.