### PR TITLE
Fix for ffmpeg 90k frame-rate guess

### DIFF
--- a/src/FM.LiveSwitch.Connect/FFRenderer.cs
+++ b/src/FM.LiveSwitch.Connect/FFRenderer.cs
@@ -280,7 +280,15 @@ namespace FM.LiveSwitch.Connect
 
             args.Add(Options.OutputArgs);
 
-            FFmpeg = FFUtility.FFmpeg(string.Join(" ", args));
+            FFmpeg = FFUtility.FFmpeg(string.Join(" ", args), (line) =>
+            {
+                if (VideoSink != null && line.Contains("640x480, 90k tbr"))
+                {
+                    // the frame-rate has not been guessed correctly
+                    // signal exit so we can start again
+                    FFmpeg.StandardInput.Write('q');
+                }
+            });
 
             _Monitor = new Thread(() =>
             {

--- a/src/FM.LiveSwitch.Connect/FFRenderer.cs
+++ b/src/FM.LiveSwitch.Connect/FFRenderer.cs
@@ -148,8 +148,6 @@ namespace FM.LiveSwitch.Connect
                 {
                     var sink = AudioSink as RtpAudioSink;
 
-                    args.Add("-protocol_whitelist file,crypto,udp,rtp");
-
                     sink.IPAddress = "127.0.0.1";
                     sink.Port = LockedRandomizer.Next(49162, 65536);
                     sink.PayloadType = 96;
@@ -179,6 +177,11 @@ namespace FM.LiveSwitch.Connect
                         throw new Exception("Unknown audio encoding.");
                     }
 
+                    if (Options.AudioBitrate.HasValue && !RtpAudioFormat.IsFixedBitrate)
+                    {
+                        sdpMediaDescription.AddBandwidth(new Sdp.Bandwidth(Sdp.BandwidthType.ApplicationSpecific, Options.AudioBitrate.Value));
+                    }
+
                     var sdpMessage = new Sdp.Message(new Sdp.Origin("127.0.0.1"), "lsconnect")
                     {
                         ConnectionData = new Sdp.ConnectionData("127.0.0.1")
@@ -196,7 +199,11 @@ namespace FM.LiveSwitch.Connect
 
                     Console.Error.WriteLine($"Audio SDP:{Environment.NewLine}{sdp}");
 
-                    args.Add($"-i {AudioSdpFileName}");
+                    args.AddRange(new[]
+                    {
+                        $"-protocol_whitelist file,crypto,udp,rtp",
+                        $"-i {AudioSdpFileName}"
+                    });
                 }
             }
 
@@ -215,8 +222,6 @@ namespace FM.LiveSwitch.Connect
                 else
                 {
                     var sink = VideoSink as RtpVideoSink;
-
-                    args.Add("-protocol_whitelist file,crypto,udp,rtp");
 
                     sink.IPAddress = "127.0.0.1";
                     sink.Port = LockedRandomizer.Next(49162, 65536);
@@ -243,6 +248,11 @@ namespace FM.LiveSwitch.Connect
                         throw new Exception("Unknown video format.");
                     }
 
+                    if (Options.VideoBitrate.HasValue && !RtpVideoFormat.IsFixedBitrate)
+                    {
+                        sdpMediaDescription.AddBandwidth(new Sdp.Bandwidth(Sdp.BandwidthType.ApplicationSpecific, Options.VideoBitrate.Value));
+                    }
+
                     var sdpMessage = new Sdp.Message(new Sdp.Origin("127.0.0.1"), "lsconnect")
                     {
                         ConnectionData = new Sdp.ConnectionData("127.0.0.1")
@@ -260,7 +270,11 @@ namespace FM.LiveSwitch.Connect
 
                     Console.Error.WriteLine($"Video SDP:{Environment.NewLine}{sdp}");
 
-                    args.Add($"-i {VideoSdpFileName}");
+                    args.AddRange(new[]
+                    {
+                        $"-protocol_whitelist file,crypto,udp,rtp",
+                        $"-i {VideoSdpFileName}"
+                    });
                 }
             }
 

--- a/src/FM.LiveSwitch.Connect/FFUtility.cs
+++ b/src/FM.LiveSwitch.Connect/FFUtility.cs
@@ -7,17 +7,17 @@ namespace FM.LiveSwitch.Connect
 {
     internal static class FFUtility
     {
-        public static Process FFmpeg(string arguments)
+        public static Process FFmpeg(string arguments, Action<string> onOutput = null)
         {
-            return Execute("ffmpeg", arguments, true, true);
+            return Execute("ffmpeg", arguments, true, true, onOutput);
         }
 
-        public static Process FFprobe(string arguments)
+        public static Process FFprobe(string arguments, Action<string> onOutput = null)
         {
-            return Execute("ffprobe", arguments, false, false);
+            return Execute("ffprobe", arguments, false, false, onOutput);
         }
 
-        private static Process Execute(string command, string arguments, bool useStandardError, bool logOutput)
+        private static Process Execute(string command, string arguments, bool useStandardError, bool logOutput, Action<string> onOutput)
         {
             // prep the process arguments
             var processStartInfo = new ProcessStartInfo
@@ -58,6 +58,10 @@ namespace FM.LiveSwitch.Connect
                             if (logOutput)
                             {
                                 Console.Error.WriteLine(line);
+                            }
+                            if (onOutput != null)
+                            {
+                                onOutput(line);
                             }
                         }
                     }

--- a/src/FM.LiveSwitch.Connect/RtpReader.cs
+++ b/src/FM.LiveSwitch.Connect/RtpReader.cs
@@ -113,7 +113,7 @@ namespace FM.LiveSwitch.Connect
 
         private async Task Loop()
         {
-            var dispatchQueue = new DispatchQueue<UdpReceiveResult>(async (result) =>
+            var dispatchQueue = new DispatchQueue<UdpReceiveResult>((result) =>
             {
                 var buffer = DataBuffer.Wrap(result.Buffer);
                 var header = RtpPacketHeader.ReadFrom(buffer);


### PR DESCRIPTION
- Updated `ffrender` to monitor `ffmpeg` output and restart the process if it guesses the stream frame-rate incorrectly.
- Updated `ffrender` to include the bitrate estimate if specified by `--audio-bitrate` or `--video-bitrate`.