### PR TITLE
Variety of fixes

### DIFF
--- a/src/FM.LiveSwitch.Connect/FFRenderOptions.cs
+++ b/src/FM.LiveSwitch.Connect/FFRenderOptions.cs
@@ -22,5 +22,8 @@ namespace FM.LiveSwitch.Connect
 
         [Option("keyframe-interval", Required = false, Default = 60, HelpText = "The keyframe interval for video, in frames. Only used if video-mode is nodecode.")]
         public int KeyFrameInterval { get; set; }
+
+        [Option("video-frame-rate", Required = false, HelpText = "The video frame rate in frames per second, if known. Only used if video-mode is nodecode.")]
+        public int? VideoFrameRate { get; set; }
     }
 }

--- a/src/FM.LiveSwitch.Connect/FFRenderer.cs
+++ b/src/FM.LiveSwitch.Connect/FFRenderer.cs
@@ -286,11 +286,16 @@ namespace FM.LiveSwitch.Connect
 
             FFmpeg = FFUtility.FFmpeg(string.Join(" ", args), (line) =>
             {
-                if (VideoSink != null && line.Contains("90k tbr"))
+                if (VideoSink != null)
                 {
-                    // the frame-rate has not been guessed correctly
-                    // signal exit so we can start again
-                    FFmpeg.StandardInput.Write('q');
+                    if (line.Contains("90k tbr") ||
+                        line.Contains(".sdp: Unknown error") ||
+                        line.Contains(".sdp: Invalid data"))
+                    {
+                        // the frame-rate has not been guessed correctly
+                        // signal exit so we can start again
+                        FFmpeg.StandardInput.Write('q');
+                    }
                 }
             });
 

--- a/src/FM.LiveSwitch.Connect/FFRenderer.cs
+++ b/src/FM.LiveSwitch.Connect/FFRenderer.cs
@@ -288,11 +288,10 @@ namespace FM.LiveSwitch.Connect
             {
                 if (VideoSink != null)
                 {
-                    if (line.Contains("90k tbr") ||
-                        line.Contains(".sdp: Unknown error") ||
-                        line.Contains(".sdp: Invalid data"))
+                    if (line.Contains("90k tbr") ||             // video frame-rate has not been guessed correctly (90,000fps is too much)
+                        line.Contains(".sdp: Unknown error") || // input media has trigger an unknown error
+                        line.Contains(".sdp: Invalid data"))    // input media is not appreciated
                     {
-                        // the frame-rate has not been guessed correctly
                         // signal exit so we can start again
                         FFmpeg.StandardInput.Write('q');
                     }

--- a/src/FM.LiveSwitch.Connect/FFRenderer.cs
+++ b/src/FM.LiveSwitch.Connect/FFRenderer.cs
@@ -284,7 +284,7 @@ namespace FM.LiveSwitch.Connect
 
             args.Add(Options.OutputArgs);
 
-            FFmpeg = FFUtility.FFmpeg(string.Join(" ", args), (line) =>
+            var onOutput = new Action<string>((line) =>
             {
                 if (VideoSink != null)
                 {
@@ -298,6 +298,8 @@ namespace FM.LiveSwitch.Connect
                 }
             });
 
+            FFmpeg = FFUtility.FFmpeg(string.Join(" ", args), onOutput);
+
             _Monitor = new Thread(() =>
             {
                 while (!_Done)
@@ -306,7 +308,7 @@ namespace FM.LiveSwitch.Connect
                     if (!_Done)
                     {
                         Console.Error.WriteLine("FFmpeg exited unexpectedly.");
-                        FFmpeg = FFUtility.FFmpeg(string.Join(" ", args));
+                        FFmpeg = FFUtility.FFmpeg(string.Join(" ", args), onOutput);
                     }
                 }
             })

--- a/src/FM.LiveSwitch.Connect/Program.cs
+++ b/src/FM.LiveSwitch.Connect/Program.cs
@@ -123,27 +123,36 @@ namespace FM.LiveSwitch.Connect
 
         private static void Initialize(Options options)
         {
-            Log.AddProvider(new ErrorLogProvider(options.LogLevel));
-
             Console.Error.WriteLine("Checking for OpenH264...");
-            OpenH264.Utility.DownloadOpenH264(Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location)).GetAwaiter().GetResult();
             options.DisableOpenH264 = true;
             try
             {
                 options.DisableOpenH264 = !OpenH264.Utility.Initialize();
-                if (options.DisableOpenH264)
-                {
-                    Console.Error.WriteLine("OpenH264 failed to initialize.");
-                }
-                else
-                {
-                    Console.Error.WriteLine("OpenH264 initialized.");
-                }
             }
-            catch (Exception ex)
+            catch { }
+
+            if (options.DisableOpenH264)
             {
-                Console.Error.WriteLine($"OpenH264 failed to initialize. {ex}");
+                OpenH264.Utility.DownloadOpenH264(Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location)).GetAwaiter().GetResult();
+                try
+                {
+                    options.DisableOpenH264 = !OpenH264.Utility.Initialize();
+                    if (options.DisableOpenH264)
+                    {
+                        Console.Error.WriteLine("OpenH264 failed to initialize.");
+                    }
+                    else
+                    {
+                        Console.Error.WriteLine("OpenH264 initialized.");
+                    }
+                }
+                catch (Exception ex)
+                {
+                    Console.Error.WriteLine($"OpenH264 failed to initialize. {ex}");
+                }
             }
+
+            Log.AddProvider(new ErrorLogProvider(options.LogLevel));
         }
     }
 }


### PR DESCRIPTION
- Added `video-frame-rate` argument for `ffrender` to assist with constant frame-rate scenarios.
- Added more intelligent `ffmpeg` lifecycle management in `ffrender` if something goes wrong.
- Fixed bug where multiple `lsconnect` instances could compete while downloading OpenH264.
- Improved connection retry logic if a connection fails to load the first time.