### PR TITLE
Adjust Target Bitrate for Audio Codecs

### DIFF
--- a/src/FM.LiveSwitch.Connect/AudioEncodingExtensions.cs
+++ b/src/FM.LiveSwitch.Connect/AudioEncodingExtensions.cs
@@ -21,21 +21,31 @@ namespace FM.LiveSwitch.Connect
             }
         }
 
-        public static AudioEncoder CreateEncoder(this AudioEncoding encoding)
+        public static AudioEncoder CreateEncoder(this AudioEncoding encoding, int? targetBitrate = null)
         {
+            AudioEncoder encoder = null;
             switch (encoding)
             {
                 case AudioEncoding.Opus:
-                    return new Opus.Encoder();
+                    encoder = new Opus.Encoder();
+                    break;
                 case AudioEncoding.G722:
-                    return new G722.Encoder();
+                    encoder = new G722.Encoder();
+                    break;
                 case AudioEncoding.PCMU:
-                    return new Pcmu.Encoder();
+                   encoder = new Pcmu.Encoder();
+                    break;
                 case AudioEncoding.PCMA:
-                    return new Pcma.Encoder();
+                    encoder = new Pcma.Encoder();
+                    break;
                 default:
                     throw new Exception("Unknown audio encoding.");
             }
+            if (targetBitrate.HasValue)
+            {
+                encoder.TargetBitrate = targetBitrate.Value;
+            }
+            return encoder;
         }
 
         public static AudioDecoder CreateDecoder(this AudioEncoding encoding)

--- a/src/FM.LiveSwitch.Connect/Receiver.cs
+++ b/src/FM.LiveSwitch.Connect/Receiver.cs
@@ -340,7 +340,7 @@ namespace FM.LiveSwitch.Connect
 
                     if (currentInput.InputFormat.IsCompressed)
                     {
-                        AudioEncoder = currentInput.InputFormat.ToEncoding().CreateEncoder();
+                        AudioEncoder = currentInput.InputFormat.ToEncoding().CreateEncoder(Options.AudioBitrate);
 
                         currentInput.AddInput(AudioEncoder);
                         currentInput = AudioEncoder;

--- a/src/FM.LiveSwitch.Connect/Sender.cs
+++ b/src/FM.LiveSwitch.Connect/Sender.cs
@@ -306,7 +306,7 @@ namespace FM.LiveSwitch.Connect
 
                 if (!currentOutput.OutputFormat.IsCompressed)
                 {
-                    AudioEncoder = AudioFormat.ToEncoding().CreateEncoder();
+                    AudioEncoder = AudioFormat.ToEncoding().CreateEncoder(Options.AudioBitrate);
 
                     AudioConverter = new SoundConverter(currentOutput.Config, AudioEncoder.InputConfig);
 


### PR DESCRIPTION
LSEncode audio encoders now take into account the audio bitrate option for outgoing streams. Useful for clients who want to increase the outgoing audio quality for non voip applications.