### PR TITLE
NDI Optimization

### DIFF
--- a/src/FM.LiveSwitch.Connect/NdiRenderOptions.cs
+++ b/src/FM.LiveSwitch.Connect/NdiRenderOptions.cs
@@ -20,10 +20,10 @@ namespace FM.LiveSwitch.Connect
         [Option("video-format", Required = false, Default = ImageFormat.Bgr, HelpText = "The video format.")]
         public ImageFormat VideoFormat { get; set; }
         
-        [Option("video-width", Required = false, Default = 800, HelpText = "The video width.")]
+        [Option("video-width", Required = false, Default = 1920, HelpText = "The video width.")]
         public int VideoWidth { get; set; }
 
-        [Option("video-height", Required = false, Default = 800, HelpText = "The video height.")]
+        [Option("video-height", Required = false, Default = 1080, HelpText = "The video height.")]
         public int VideoHeight { get; set; }
 
         [Option("frame-rate-numerator", Required = false, Default = 30000, HelpText = "The frame rate numerator")]

--- a/src/FM.LiveSwitch.Connect/NdiRenderer.cs
+++ b/src/FM.LiveSwitch.Connect/NdiRenderer.cs
@@ -89,13 +89,15 @@ namespace FM.LiveSwitch.Connect
             _Log.Info("Ndi Audio Sink Created");
             var maxRate = Options.AudioClockRate / 1000 * Options.AudioFrameDuration; // 1000ms
             var sink = new NdiAudioSink(NdiSender, maxRate,  Options.AudioClockRate, Options.AudioChannelCount, new Pcm.Format(Options.AudioClockRate, Options.AudioChannelCount));
+
+            
             return sink;
         }
 
         protected override NdiVideoSink CreateVideoSink()
         {
             _Log.Info("Ndi Video Sink Created");
-            var sink = new NdiVideoSink(NdiSender, Options.VideoWidth, Options.VideoHeight, Options.FrameRateNumerator, Options.FrameRateDenominator, VideoFormat.Bgra);
+            var sink = new NdiVideoSink(NdiSender, Options.FrameRateNumerator, Options.FrameRateDenominator, VideoFormat.I420);
             return sink;
         }
 
@@ -108,13 +110,16 @@ namespace FM.LiveSwitch.Connect
         {
             string failoverName = $"{System.Net.Dns.GetHostName()}-{Options.StreamName}";
             _Log.Info($"Initializing NDI Stream - {Options.StreamName} (Alt: {failoverName})");
-            NdiSender = new Sender(Options.StreamName, true, false, null, failoverName);
+
+            // Faster to put the clock on audio as opposed to video
+            NdiSender = new Sender(Options.StreamName, false, true, null, failoverName);
             
             return base.Initialize();
         }
 
         protected override Task Ready()
         {
+
             var videoConverter = VideoConverter;
             if (videoConverter != null)
             {

--- a/src/NDILibDotNet2/VideoFrame.cs
+++ b/src/NDILibDotNet2/VideoFrame.cs
@@ -19,7 +19,7 @@ namespace NewTek.NDI
 
             // allocate some memory for a video buffer
             IntPtr videoBufferPtr = Marshal.AllocHGlobal(bufferSize);
-
+            
             _ndiVideoFrame = new NDIlib.video_frame_v2_t()
             {
                 xres = width,
@@ -31,7 +31,7 @@ namespace NewTek.NDI
                 frame_format_type = format,
                 timecode = NDIlib.send_timecode_synthesize,
                 p_data = videoBufferPtr,
-                line_stride_in_bytes = stride,
+                line_stride_in_bytes = stride,              
                 p_metadata = IntPtr.Zero,
                 timestamp = 0
             };


### PR DESCRIPTION
- Set clock on audio as opposed to video - adds slight performance improvement. 
- Ensure format remains I420 to avoid any conversions between what is received and what is sent to NDI - update the implementation of the NDI frame to ensure it will support I420. 

Reduces the latency from about 20 frames to around 4. 