### PR TITLE
Reconnecting a receiver targeting a media ID

### DIFF
--- a/src/FM.LiveSwitch.Connect/Receiver.cs
+++ b/src/FM.LiveSwitch.Connect/Receiver.cs
@@ -105,6 +105,7 @@ namespace FM.LiveSwitch.Connect
                             }
                             else
                             {
+                                RemoteConnectionInfo = null;
                                 Console.Error.WriteLine($"{GetType().Name} has remote media ID '{Options.MediaId}'.");
                             }
 


### PR DESCRIPTION
- Fixed a bug where a receiver (e.g. `ndirender`) targeting a media ID using `--media-id` would fail to target that same media ID after an automatic reconnection (e.g. due to a temporary network failure).

Closes #43.