### PR TITLE
Fix rollover size casting

### DIFF
--- a/src/FM.LiveSwitch.Connect/RolloverContext.cs
+++ b/src/FM.LiveSwitch.Connect/RolloverContext.cs
@@ -10,7 +10,7 @@ namespace FM.LiveSwitch.Connect
             set
             {
                 _Bits = value;
-                _RolloverSize = (int)MathAssistant.Pow(2, _Bits);
+                _RolloverSize = (long)MathAssistant.Pow(2, _Bits);
                 _RolloverSize_2 = _RolloverSize / 2;
             }
         }


### PR DESCRIPTION
Rollover size is getting set to a negative value when bits == 32 since it's being casted to a signed integer value. While Pow() produces a double, it should be casted to a long since that's where it's being stored.